### PR TITLE
[US-1.4] Add automatic Railway deploy on develop push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,16 +170,16 @@ jobs:
           path: frontend/build/app/outputs/flutter-apk/app-release.apk
           retention-days: 7
 
-  # Deploy Job (only on main)
+  # Deploy to Railway (staging on develop)
   deploy:
-    name: Deploy
+    name: Deploy to Railway
     runs-on: ubuntu-latest
-    needs: [backend-build, frontend-build]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    needs: [backend-build]
+    if: github.ref == 'refs/heads/develop' && github.event_name == 'push'
     steps:
-      - name: Deploy notification
-        run: echo "🚀 Ready to deploy! Add deployment steps here."
-      
-      # TODO: Add actual deployment steps
-      # - Railway deploy for backend
-      # - App store upload for frontend
+      - uses: actions/checkout@v4
+
+      - name: Deploy to Railway
+        uses: railwayapp/deploy@v3
+        with:
+          railway_token: ${{ secrets.RAILWAY_TOKEN }}


### PR DESCRIPTION
## Summary

Configure automatic deployment to Railway when changes are pushed to the `develop` branch.

## Changes

### T-1.4.3: Configure Railway Deploy (#25)

- Updated deploy job to trigger on `develop` branch push (staging environment)
- Changed from placeholder to actual `railwayapp/deploy@v3` action
- Removed frontend-build dependency (backend-only for staging)
- Uses `RAILWAY_TOKEN` secret for authentication

## How It Works

```mermaid
flowchart LR
    A[Push to develop] --> B[CI: Lint]
    B --> C[CI: Test]
    C --> D[CI: Build]
    D --> E[Deploy to Railway]
    E --> F[Staging Live]
```

## Configuration

- **Trigger**: Push to `develop` branch only
- **Dependency**: Requires `backend-build` job to pass
- **Secret**: `RAILWAY_TOKEN` (already configured in GitHub Secrets)

## Verification

After merge:
1. Push to develop will trigger deployment
2. Railway will build and deploy automatically
3. Health check: https://wealthscope-production.up.railway.app/health

## Issues Addressed

Closes #25
Part of #22 (US-1.4)