### PR TITLE
feat(frontend): modernize color palette and unify hardcoded colors

### DIFF
--- a/frontend/lib/core/theme/app_theme.dart
+++ b/frontend/lib/core/theme/app_theme.dart
@@ -7,13 +7,40 @@ class AppTheme {
   AppTheme._();
 
   // ============================================================================
-  // BRAND COLORS
+  // BRAND COLORS - Modern Financial App Palette
   // ============================================================================
-  static const Color primaryColor = Color(0xFF1E3A5F);
-  static const Color secondaryColor = Color(0xFF3D8B7F);
-  static const Color accentColor = Color(0xFFFFB800);
-  static const Color errorColor = Color(0xFFE53935);
-  static const Color successColor = Color(0xFF43A047);
+  static const Color primaryColor = Color(0xFF6366F1);    // Indigo - Main actions
+  static const Color secondaryColor = Color(0xFF10B981);  // Emerald - Success/Gains
+  static const Color accentColor = Color(0xFFF59E0B);     // Amber - Accents/Warnings
+  static const Color errorColor = Color(0xFFEF4444);      // Red - Errors/Losses
+  static const Color successColor = Color(0xFF10B981);    // Emerald - Same as secondary
+  
+  // ============================================================================
+  // SEMANTIC COLORS - For financial data display
+  // ============================================================================
+  static const Color gainColor = Color(0xFF10B981);       // Green for gains
+  static const Color lossColor = Color(0xFFEF4444);       // Red for losses
+  static const Color neutralColor = Color(0xFF6B7280);    // Gray for neutral
+  
+  // ============================================================================
+  // SURFACE COLORS
+  // ============================================================================
+  static const Color surfaceLight = Color(0xFFF8FAFC);    // Light mode background
+  static const Color surfaceDark = Color(0xFF0F172A);     // Dark mode background
+  
+  // ============================================================================
+  // CHART COLORS - For pie charts and graphs
+  // ============================================================================
+  static const List<Color> chartColors = [
+    Color(0xFF6366F1),  // Indigo
+    Color(0xFF10B981),  // Emerald
+    Color(0xFFF59E0B),  // Amber
+    Color(0xFFEC4899),  // Pink
+    Color(0xFF8B5CF6),  // Violet
+    Color(0xFF06B6D4),  // Cyan
+    Color(0xFFF97316),  // Orange
+    Color(0xFF84CC16),  // Lime
+  ];
   
   // ============================================================================
   // SPACING (8px base unit)
@@ -75,6 +102,7 @@ class AppTheme {
         secondary: secondaryColor,
         error: errorColor,
         tertiary: accentColor,
+        surface: surfaceLight,
       ),
       
       // Typography
@@ -144,19 +172,30 @@ class AppTheme {
         ),
       ),
       
-      // AppBar
-      appBarTheme: const AppBarTheme(
-        centerTitle: true,
+      // AppBar - Clean, modern look
+      appBarTheme: AppBarTheme(
+        centerTitle: false,
         elevation: 0,
-        backgroundColor: primaryColor,
-        foregroundColor: Colors.white,
+        scrolledUnderElevation: 1,
+        backgroundColor: surfaceLight,
+        foregroundColor: const Color(0xFF1E293B),
+        surfaceTintColor: Colors.transparent,
+        titleTextStyle: const TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: Color(0xFF1E293B),
+          fontFamily: 'Inter',
+        ),
       ),
       
       // Card
       cardTheme: CardThemeData(
         elevation: 0,
+        color: Colors.white,
+        surfaceTintColor: Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(radiusMd),
+          side: const BorderSide(color: Color(0xFFE2E8F0), width: 1),
         ),
         margin: const EdgeInsets.all(spacingSm),
       ),
@@ -164,18 +203,44 @@ class AppTheme {
       // Input Decoration
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
+        fillColor: const Color(0xFFF1F5F9),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: Color(0xFFE2E8F0)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: primaryColor, width: 2),
         ),
         contentPadding: const EdgeInsets.symmetric(
           horizontal: spacingMd,
-          vertical: spacingSm,
+          vertical: spacingMd,
         ),
       ),
       
       // Elevated Button
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
+          backgroundColor: primaryColor,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(
+            horizontal: spacingLg,
+            vertical: spacingMd,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(radiusSm),
+          ),
+          elevation: 0,
+        ),
+      ),
+      
+      // Filled Button
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
           padding: const EdgeInsets.symmetric(
             horizontal: spacingLg,
             vertical: spacingMd,
@@ -188,9 +253,21 @@ class AppTheme {
       
       // Floating Action Button
       floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: primaryColor,
+        foregroundColor: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(radiusMd),
         ),
+        elevation: 2,
+      ),
+      
+      // Bottom Navigation Bar
+      bottomNavigationBarTheme: const BottomNavigationBarThemeData(
+        backgroundColor: Colors.white,
+        selectedItemColor: primaryColor,
+        unselectedItemColor: Color(0xFF94A3B8),
+        type: BottomNavigationBarType.fixed,
+        elevation: 8,
       ),
     );
   }
@@ -208,6 +285,7 @@ class AppTheme {
         secondary: secondaryColor,
         error: errorColor,
         tertiary: accentColor,
+        surface: surfaceDark,
       ),
       
       // Typography
@@ -277,19 +355,30 @@ class AppTheme {
         ),
       ),
       
-      // AppBar
+      // AppBar - Dark mode
       appBarTheme: AppBarTheme(
-        centerTitle: true,
+        centerTitle: false,
         elevation: 0,
-        backgroundColor: primaryColor.withOpacity(0.8),
-        foregroundColor: Colors.white,
+        scrolledUnderElevation: 1,
+        backgroundColor: surfaceDark,
+        foregroundColor: const Color(0xFFF1F5F9),
+        surfaceTintColor: Colors.transparent,
+        titleTextStyle: const TextStyle(
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+          color: Color(0xFFF1F5F9),
+          fontFamily: 'Inter',
+        ),
       ),
       
       // Card
       cardTheme: CardThemeData(
         elevation: 0,
+        color: const Color(0xFF1E293B),
+        surfaceTintColor: Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(radiusMd),
+          side: const BorderSide(color: Color(0xFF334155), width: 1),
         ),
         margin: const EdgeInsets.all(spacingSm),
       ),
@@ -297,18 +386,44 @@ class AppTheme {
       // Input Decoration
       inputDecorationTheme: InputDecorationTheme(
         filled: true,
+        fillColor: const Color(0xFF1E293B),
         border: OutlineInputBorder(
           borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: BorderSide.none,
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: Color(0xFF334155)),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(radiusSm),
+          borderSide: const BorderSide(color: primaryColor, width: 2),
         ),
         contentPadding: const EdgeInsets.symmetric(
           horizontal: spacingMd,
-          vertical: spacingSm,
+          vertical: spacingMd,
         ),
       ),
       
       // Elevated Button
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ElevatedButton.styleFrom(
+          backgroundColor: primaryColor,
+          foregroundColor: Colors.white,
+          padding: const EdgeInsets.symmetric(
+            horizontal: spacingLg,
+            vertical: spacingMd,
+          ),
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(radiusSm),
+          ),
+          elevation: 0,
+        ),
+      ),
+      
+      // Filled Button
+      filledButtonTheme: FilledButtonThemeData(
+        style: FilledButton.styleFrom(
           padding: const EdgeInsets.symmetric(
             horizontal: spacingLg,
             vertical: spacingMd,
@@ -321,10 +436,38 @@ class AppTheme {
       
       // Floating Action Button
       floatingActionButtonTheme: FloatingActionButtonThemeData(
+        backgroundColor: primaryColor,
+        foregroundColor: Colors.white,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(radiusMd),
         ),
+        elevation: 2,
+      ),
+      
+      // Bottom Navigation Bar
+      bottomNavigationBarTheme: BottomNavigationBarThemeData(
+        backgroundColor: surfaceDark,
+        selectedItemColor: primaryColor,
+        unselectedItemColor: const Color(0xFF64748B),
+        type: BottomNavigationBarType.fixed,
+        elevation: 8,
       ),
     );
+  }
+  
+  // ============================================================================
+  // HELPER METHODS
+  // ============================================================================
+  
+  /// Returns the appropriate color for a value change (gain/loss)
+  static Color getChangeColor(double change) {
+    if (change > 0) return gainColor;
+    if (change < 0) return lossColor;
+    return neutralColor;
+  }
+  
+  /// Returns a chart color by index (cycles through chartColors)
+  static Color getChartColor(int index) {
+    return chartColors[index % chartColors.length];
   }
 }

--- a/frontend/lib/core/utils/snackbar_utils.dart
+++ b/frontend/lib/core/utils/snackbar_utils.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wealthscope_app/core/theme/app_theme.dart';
 
 /// Snackbar Utility Functions
 /// Provides consistent success/error notifications throughout the app
@@ -25,7 +26,7 @@ class SnackbarUtils {
               ),
             ],
           ),
-          backgroundColor: Colors.green,
+          backgroundColor: AppTheme.successColor,
           behavior: SnackBarBehavior.floating,
           duration: const Duration(seconds: 3),
         ),
@@ -52,7 +53,7 @@ class SnackbarUtils {
               ),
             ],
           ),
-          backgroundColor: Colors.red,
+          backgroundColor: AppTheme.errorColor,
           behavior: SnackBarBehavior.floating,
           duration: const Duration(seconds: 4),
           action: SnackBarAction(
@@ -86,7 +87,7 @@ class SnackbarUtils {
               ),
             ],
           ),
-          backgroundColor: Colors.blue,
+          backgroundColor: AppTheme.primaryColor,
           behavior: SnackBarBehavior.floating,
           duration: const Duration(seconds: 3),
         ),

--- a/frontend/lib/features/assets/presentation/widgets/asset_detail_header.dart
+++ b/frontend/lib/features/assets/presentation/widgets/asset_detail_header.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wealthscope_app/core/theme/app_theme.dart';
 import 'package:wealthscope_app/features/assets/domain/entities/asset_type.dart';
 import 'package:wealthscope_app/features/assets/domain/entities/stock_asset.dart';
 
@@ -17,6 +18,7 @@ class AssetDetailHeader extends StatelessWidget {
     final theme = Theme.of(context);
     final gainLoss = asset.gainLoss;
     final isPositive = gainLoss != null && gainLoss >= 0;
+    final changeColor = AppTheme.getChangeColor(gainLoss ?? 0);
 
     return Container(
       padding: const EdgeInsets.all(24),
@@ -86,9 +88,7 @@ class AssetDetailHeader extends StatelessWidget {
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
               decoration: BoxDecoration(
-                color: isPositive
-                    ? Colors.green.withOpacity(0.2)
-                    : Colors.red.withOpacity(0.2),
+                color: changeColor.withOpacity(0.2),
                 borderRadius: BorderRadius.circular(8),
               ),
               child: Row(
@@ -97,13 +97,13 @@ class AssetDetailHeader extends StatelessWidget {
                   Icon(
                     isPositive ? Icons.trending_up : Icons.trending_down,
                     size: 20,
-                    color: isPositive ? Colors.green : Colors.red,
+                    color: changeColor,
                   ),
                   const SizedBox(width: 4),
                   Text(
                     '${isPositive ? '+' : ''}${asset.currency.symbol}${_formatPrice(gainLoss)} (${asset.gainLossPercent!.toStringAsFixed(2)}%)',
                     style: theme.textTheme.titleMedium?.copyWith(
-                      color: isPositive ? Colors.green : Colors.red,
+                      color: changeColor,
                       fontWeight: FontWeight.bold,
                     ),
                   ),

--- a/frontend/lib/features/assets/presentation/widgets/asset_list_skeleton.dart
+++ b/frontend/lib/features/assets/presentation/widgets/asset_list_skeleton.dart
@@ -26,13 +26,15 @@ class AssetCardSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final isDark = theme.brightness == Brightness.dark;
+    final baseColor = theme.colorScheme.surfaceContainerHighest;
+    final highlightColor = theme.colorScheme.surfaceContainerLow;
+    final shimmerColor = theme.colorScheme.surfaceContainerHighest;
 
     return Card(
       margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
       child: Shimmer.fromColors(
-        baseColor: isDark ? Colors.grey[800]! : Colors.grey[300]!,
-        highlightColor: isDark ? Colors.grey[700]! : Colors.grey[100]!,
+        baseColor: baseColor,
+        highlightColor: highlightColor,
         child: Padding(
           padding: const EdgeInsets.all(16),
           child: Row(
@@ -42,7 +44,7 @@ class AssetCardSkeleton extends StatelessWidget {
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: Colors.white,
+                  color: shimmerColor,
                   borderRadius: BorderRadius.circular(12),
                 ),
               ),
@@ -58,7 +60,7 @@ class AssetCardSkeleton extends StatelessWidget {
                       width: 120,
                       height: 16,
                       decoration: BoxDecoration(
-                        color: Colors.white,
+                        color: shimmerColor,
                         borderRadius: BorderRadius.circular(4),
                       ),
                     ),
@@ -68,7 +70,7 @@ class AssetCardSkeleton extends StatelessWidget {
                       width: 80,
                       height: 12,
                       decoration: BoxDecoration(
-                        color: Colors.white,
+                        color: shimmerColor,
                         borderRadius: BorderRadius.circular(4),
                       ),
                     ),
@@ -85,7 +87,7 @@ class AssetCardSkeleton extends StatelessWidget {
                     width: 50,
                     height: 14,
                     decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: shimmerColor,
                       borderRadius: BorderRadius.circular(4),
                     ),
                   ),
@@ -95,7 +97,7 @@ class AssetCardSkeleton extends StatelessWidget {
                     width: 70,
                     height: 16,
                     decoration: BoxDecoration(
-                      color: Colors.white,
+                      color: shimmerColor,
                       borderRadius: BorderRadius.circular(4),
                     ),
                   ),

--- a/frontend/lib/features/dashboard/presentation/widgets/allocation_legend.dart
+++ b/frontend/lib/features/dashboard/presentation/widgets/allocation_legend.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:wealthscope_app/core/theme/app_theme.dart';
 import 'package:wealthscope_app/features/assets/domain/entities/asset_type.dart';
 import 'package:wealthscope_app/features/dashboard/domain/entities/portfolio_summary.dart';
 
@@ -114,25 +115,25 @@ class AllocationLegend extends StatelessWidget {
   }
 
   /// Get color for asset type
-  /// Returns consistent colors matching the pie chart
+  /// Returns consistent colors matching the pie chart using theme colors
   Color _getTypeColor(String typeString) {
     final type = _parseAssetType(typeString);
 
     switch (type) {
       case AssetType.stock:
-        return Colors.blue;
+        return AppTheme.getChartColor(0);  // Indigo
       case AssetType.etf:
-        return Colors.indigo;
+        return AppTheme.getChartColor(4);  // Violet
       case AssetType.realEstate:
-        return Colors.green;
+        return AppTheme.getChartColor(1);  // Emerald
       case AssetType.gold:
-        return Colors.amber;
+        return AppTheme.getChartColor(2);  // Amber
       case AssetType.crypto:
-        return Colors.orange;
+        return AppTheme.getChartColor(6);  // Orange
       case AssetType.bond:
-        return Colors.purple;
+        return AppTheme.getChartColor(3);  // Pink
       case AssetType.other:
-        return Colors.grey;
+        return AppTheme.neutralColor;
     }
   }
 

--- a/frontend/lib/features/dashboard/presentation/widgets/dashboard_skeleton.dart
+++ b/frontend/lib/features/dashboard/presentation/widgets/dashboard_skeleton.dart
@@ -9,8 +9,14 @@ class DashboardSkeleton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final baseColor = theme.colorScheme.surfaceVariant;
-    final highlightColor = theme.colorScheme.surface;
+    final isDark = theme.brightness == Brightness.dark;
+    final baseColor = isDark 
+        ? theme.colorScheme.surfaceContainerHighest 
+        : theme.colorScheme.surfaceContainerHighest;
+    final highlightColor = isDark 
+        ? theme.colorScheme.surfaceContainerLow 
+        : theme.colorScheme.surface;
+    final shimmerColor = theme.colorScheme.surfaceContainerHighest;
 
     return Shimmer.fromColors(
       baseColor: baseColor,
@@ -22,7 +28,7 @@ class DashboardSkeleton extends StatelessWidget {
           Container(
             height: 180,
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: shimmerColor,
               borderRadius: BorderRadius.circular(12),
             ),
           ),
@@ -31,7 +37,7 @@ class DashboardSkeleton extends StatelessWidget {
           Container(
             height: 280,
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: shimmerColor,
               borderRadius: BorderRadius.circular(12),
             ),
           ),
@@ -40,7 +46,7 @@ class DashboardSkeleton extends StatelessWidget {
           Container(
             height: 120,
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: shimmerColor,
               borderRadius: BorderRadius.circular(12),
             ),
           ),
@@ -49,7 +55,7 @@ class DashboardSkeleton extends StatelessWidget {
           Container(
             height: 200,
             decoration: BoxDecoration(
-              color: Colors.white,
+              color: shimmerColor,
               borderRadius: BorderRadius.circular(12),
             ),
           ),

--- a/frontend/lib/features/dashboard/presentation/widgets/portfolio_summary_card.dart
+++ b/frontend/lib/features/dashboard/presentation/widgets/portfolio_summary_card.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:wealthscope_app/core/theme/app_theme.dart';
 import 'package:wealthscope_app/features/dashboard/domain/entities/portfolio_summary.dart';
 
 /// Portfolio Summary Card Widget
@@ -16,6 +17,7 @@ class PortfolioSummaryCard extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final isPositive = summary.totalGain >= 0;
+    final changeColor = AppTheme.getChangeColor(summary.totalGain);
 
     return Card(
       elevation: 4,
@@ -63,14 +65,14 @@ class PortfolioSummaryCard extends StatelessWidget {
                   children: [
                     Icon(
                       isPositive ? Icons.arrow_upward : Icons.arrow_downward,
-                      color: isPositive ? Colors.greenAccent : Colors.redAccent,
+                      color: changeColor,
                       size: 16,
                     ),
                     const SizedBox(width: 4),
                     Text(
                       '${isPositive ? "+" : ""}\$${summary.totalGain.abs().toStringAsFixed(0)} (${summary.totalGainPercentage.toStringAsFixed(1)}%)',
                       style: theme.textTheme.bodyMedium?.copyWith(
-                        color: isPositive ? Colors.greenAccent : Colors.redAccent,
+                        color: changeColor,
                         fontWeight: FontWeight.w500,
                       ),
                     ),

--- a/frontend/lib/features/dashboard/presentation/widgets/top_assets_section.dart
+++ b/frontend/lib/features/dashboard/presentation/widgets/top_assets_section.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:wealthscope_app/core/theme/app_theme.dart';
 import 'package:wealthscope_app/features/dashboard/domain/entities/portfolio_summary.dart';
 import 'package:intl/intl.dart';
 
@@ -50,8 +51,8 @@ class _TopAssetItem extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final numberFormat = NumberFormat.currency(symbol: '\$', decimalDigits: 2);
+    final gainColor = AppTheme.getChangeColor(asset.gain);
     final isGainPositive = asset.gain >= 0;
-    final gainColor = isGainPositive ? Colors.green : Colors.red;
 
     return Container(
       margin: const EdgeInsets.only(bottom: 12),


### PR DESCRIPTION
## Summary

Modernize the frontend color palette and unify hardcoded colors throughout the app.

## Changes

### New Color Palette
- **Primary**: `#6366F1` (Indigo) - Main actions, navigation
- **Secondary**: `#10B981` (Emerald) - Success, gains
- **Tertiary**: `#F59E0B` (Amber) - Accents, warnings
- **Error**: `#EF4444` (Red) - Errors, losses

### Theme Improvements
- Added semantic colors for gains/losses (`gainColor`, `lossColor`, `neutralColor`)
- Added chart color palette for pie charts and graphs
- Improved AppBar styling (cleaner, modern look)
- Better Card styling with borders
- Improved Input field styling
- Added `getChangeColor()` and `getChartColor()` helper methods

### Unified Hardcoded Colors
- `snackbar_utils.dart` - Now uses theme colors
- `portfolio_summary_card.dart` - Uses `AppTheme.getChangeColor()`
- `allocation_legend.dart` - Uses `AppTheme.chartColors`
- `top_assets_section.dart` - Uses `AppTheme.getChangeColor()`
- `asset_detail_header.dart` - Uses `AppTheme.getChangeColor()`
- `dashboard_skeleton.dart` - Uses theme surface colors
- `asset_list_skeleton.dart` - Uses theme surface colors

## Before/After

The app will have a more modern, vibrant look with consistent colors across all components, proper dark mode support, and semantic color meanings (green=gain, red=loss).

## Test Plan

- [ ] Verify light mode looks correct
- [ ] Verify dark mode looks correct
- [ ] Check gain/loss colors display properly
- [ ] Verify skeletons animate with correct colors