### PR TITLE
fix(frontend): use CardTheme and surfaceContainerHighest for Flutter compatibility

### DIFF
--- a/frontend/lib/core/theme/app_theme.dart
+++ b/frontend/lib/core/theme/app_theme.dart
@@ -189,7 +189,7 @@ class AppTheme {
       ),
       
       // Card
-      cardTheme: CardThemeData(
+      cardTheme: CardTheme(
         elevation: 0,
         color: Colors.white,
         surfaceTintColor: Colors.transparent,
@@ -372,7 +372,7 @@ class AppTheme {
       ),
       
       // Card
-      cardTheme: CardThemeData(
+      cardTheme: CardTheme(
         elevation: 0,
         color: const Color(0xFF1E293B),
         surfaceTintColor: Colors.transparent,

--- a/frontend/lib/features/dashboard/presentation/widgets/top_assets_section.dart
+++ b/frontend/lib/features/dashboard/presentation/widgets/top_assets_section.dart
@@ -58,7 +58,7 @@ class _TopAssetItem extends StatelessWidget {
       margin: const EdgeInsets.only(bottom: 12),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: theme.colorScheme.surfaceVariant.withOpacity(0.3),
+        color: theme.colorScheme.surfaceContainerHighest.withOpacity(0.3),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(


### PR DESCRIPTION
## Problem

The previous PR (#190) introduced errors:
- `CardThemeData` is not a valid class in Flutter - should be `CardTheme`
- `surfaceVariant` is deprecated - should be `surfaceContainerHighest`

## Changes

- Replace `CardThemeData` with `CardTheme` (2 occurrences)
- Replace `surfaceVariant` with `surfaceContainerHighest`

## Test Plan

- [ ] Flutter analyze passes
- [ ] App builds successfully