### PR TITLE
fix(db): enable PreferSimpleProtocol for all modes to fix PgBouncer errors

### DIFF
--- a/backend/internal/infrastructure/database/database.go
+++ b/backend/internal/infrastructure/database/database.go
@@ -34,12 +34,13 @@ func Connect(cfg *config.Config, zapLogger *zap.Logger) (*DB, error) {
 
 	// Open database connection
 	//
-	// NOTE: PreferSimpleProtocol avoids prepared statement caching conflicts that can
-	// happen with poolers (e.g. Supabase PgBouncer) during tests/integration runs.
-	dialector := postgres.Open(cfg.Database.URL)
-	if cfg.Server.Mode == "test" {
-		dialector = postgres.New(postgres.Config{DSN: cfg.Database.URL, PreferSimpleProtocol: true})
-	}
+	// NOTE: PreferSimpleProtocol avoids prepared statement caching conflicts that
+	// happen with connection poolers like Supabase PgBouncer. This must be enabled
+	// for ALL modes (not just test) because Supabase always uses PgBouncer.
+	dialector := postgres.New(postgres.Config{
+		DSN:                  cfg.Database.URL,
+		PreferSimpleProtocol: true,
+	})
 
 	db, err := gorm.Open(dialector, &gorm.Config{
 		Logger:                 gormLogger,


### PR DESCRIPTION
## Summary
- Enable `PreferSimpleProtocol: true` for ALL database connections, not just test mode
- Fixes "prepared statement already exists" (SQLSTATE 42P05) errors in production
- Required because Supabase uses PgBouncer in transaction mode for all environments

## Root Cause
PgBouncer reuses database connections across transactions. When GORM caches prepared statements, these can conflict when the same connection is reused by a different request. This manifests as `ERROR: prepared statement "stmtcache_xxx" already exists`.

## Test Plan
- [ ] Deploy to Railway
- [ ] Verify assets can be listed without 500 errors
- [ ] Verify portfolio summary works consistently