### PR TITLE
feat(backend): US-6.2 Stock and ETF Data with Alpha Vantage and Finnhub

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -57,16 +57,22 @@ GEMINI_MODEL=gemini-3.0-flash
 # Get key: https://www.alphavantage.co/support/#api-key
 MARKETDATA_ALPHA_VANTAGE_API_KEY=
 MARKETDATA_ALPHA_VANTAGE_ENABLED=false
+MARKETDATA_ALPHA_VANTAGE_RATE_LIMIT=5
 
 # Finnhub - stocks, market data
 # Get key: https://finnhub.io/register
 MARKETDATA_FINNHUB_API_KEY=
 MARKETDATA_FINNHUB_ENABLED=false
+MARKETDATA_FINNHUB_RATE_LIMIT=60
 
 # Yahoo Finance - public endpoint, no key required; optional RapidAPI key
 # Leave empty to use public Yahoo Finance; or https://rapidapi.com/apidojo/api/yahoo-finance1
 MARKETDATA_YAHOO_FINANCE_API_KEY=
 MARKETDATA_YAHOO_FINANCE_ENABLED=true
+MARKETDATA_YAHOO_RATE_LIMIT=100
+
+# Cache TTL for market data quotes (in seconds)
+MARKETDATA_CACHE_TTL_SECONDS=60
 
 # -----------------------------------------------------------------------------
 # RevenueCat Configuration (Subscriptions)

--- a/backend/internal/infrastructure/marketdata/alpha_vantage_client.go
+++ b/backend/internal/infrastructure/marketdata/alpha_vantage_client.go
@@ -1,0 +1,315 @@
+package marketdata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Unikyri/WealthScope/backend/internal/domain/services"
+)
+
+const (
+	alphaVantageBaseURL        = "https://www.alphavantage.co/query"
+	alphaVantageDefaultTimeout = 15 * time.Second
+)
+
+// AlphaVantageClient implements services.MarketDataClient for Alpha Vantage API.
+// Uses GLOBAL_QUOTE for current prices and TIME_SERIES_DAILY for historical data.
+// Free tier: 25 requests/day, so use conservatively as a fallback provider.
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type AlphaVantageClient struct {
+	httpClient  *http.Client
+	apiKey      string
+	baseURL     string
+	rateLimiter *RateLimiter
+}
+
+// NewAlphaVantageClient creates a new Alpha Vantage client with the given API key.
+// If rateLimiter is nil, no rate limiting is applied.
+func NewAlphaVantageClient(apiKey string, rateLimiter *RateLimiter) *AlphaVantageClient {
+	return &AlphaVantageClient{
+		httpClient: &http.Client{
+			Timeout: alphaVantageDefaultTimeout,
+		},
+		apiKey:      apiKey,
+		baseURL:     alphaVantageBaseURL,
+		rateLimiter: rateLimiter,
+	}
+}
+
+// globalQuoteResponse represents the Alpha Vantage GLOBAL_QUOTE API response.
+type globalQuoteResponse struct {
+	GlobalQuote globalQuoteData `json:"Global Quote"`
+}
+
+type globalQuoteData struct {
+	Symbol           string `json:"01. symbol"`
+	Open             string `json:"02. open"`
+	High             string `json:"03. high"`
+	Low              string `json:"04. low"`
+	Price            string `json:"05. price"`
+	Volume           string `json:"06. volume"`
+	LatestTradingDay string `json:"07. latest trading day"`
+	PreviousClose    string `json:"08. previous close"`
+	Change           string `json:"09. change"`
+	ChangePercent    string `json:"10. change percent"`
+}
+
+// timeSeriesDailyResponse represents the Alpha Vantage TIME_SERIES_DAILY API response.
+type timeSeriesDailyResponse struct {
+	MetaData   map[string]string         `json:"Meta Data"`
+	TimeSeries map[string]dailyOHLCVData `json:"Time Series (Daily)"`
+}
+
+type dailyOHLCVData struct {
+	Open   string `json:"1. open"`
+	High   string `json:"2. high"`
+	Low    string `json:"3. low"`
+	Close  string `json:"4. close"`
+	Volume string `json:"5. volume"`
+}
+
+// GetQuote fetches the latest quote for a symbol using GLOBAL_QUOTE endpoint.
+func (c *AlphaVantageClient) GetQuote(ctx context.Context, symbol string) (*services.Quote, error) {
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("alpha_vantage: rate limit wait: %w", err)
+		}
+	}
+
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, fmt.Errorf("alpha_vantage: empty symbol")
+	}
+
+	url := fmt.Sprintf("%s?function=GLOBAL_QUOTE&symbol=%s&apikey=%s", c.baseURL, symbol, c.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("alpha_vantage: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WealthScope/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("alpha_vantage: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("alpha_vantage: unexpected status %d", resp.StatusCode)
+	}
+
+	var result globalQuoteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("alpha_vantage: decode response: %w", err)
+	}
+
+	// Check for empty response (API limit reached or invalid symbol)
+	if result.GlobalQuote.Symbol == "" {
+		return nil, fmt.Errorf("alpha_vantage: no data for symbol %s (API limit or invalid symbol)", symbol)
+	}
+
+	return c.parseGlobalQuote(&result.GlobalQuote)
+}
+
+// GetQuotes fetches quotes for multiple symbols. Alpha Vantage doesn't support batch quotes,
+// so this makes sequential calls for each symbol.
+func (c *AlphaVantageClient) GetQuotes(ctx context.Context, symbols []string) (map[string]*services.Quote, error) {
+	quotes := make(map[string]*services.Quote, len(symbols))
+
+	for _, symbol := range symbols {
+		select {
+		case <-ctx.Done():
+			return quotes, ctx.Err()
+		default:
+		}
+
+		q, err := c.GetQuote(ctx, symbol)
+		if err != nil {
+			// Skip failed symbols, don't fail entire batch
+			continue
+		}
+		quotes[strings.ToUpper(symbol)] = q
+	}
+
+	return quotes, nil
+}
+
+// GetHistoricalPrices fetches daily OHLCV data using TIME_SERIES_DAILY endpoint.
+func (c *AlphaVantageClient) GetHistoricalPrices(ctx context.Context, symbol string, from, to time.Time) ([]services.PricePoint, error) {
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("alpha_vantage: rate limit wait: %w", err)
+		}
+	}
+
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, fmt.Errorf("alpha_vantage: empty symbol")
+	}
+
+	// Use outputsize=full to get more historical data (20+ years)
+	// Use outputsize=compact for only last 100 data points
+	outputSize := "compact"
+	daysDiff := to.Sub(from).Hours() / 24
+	if daysDiff > 100 {
+		outputSize = "full"
+	}
+
+	url := fmt.Sprintf("%s?function=TIME_SERIES_DAILY&symbol=%s&outputsize=%s&apikey=%s",
+		c.baseURL, symbol, outputSize, c.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("alpha_vantage: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WealthScope/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("alpha_vantage: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("alpha_vantage: unexpected status %d", resp.StatusCode)
+	}
+
+	var result timeSeriesDailyResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("alpha_vantage: decode response: %w", err)
+	}
+
+	if len(result.TimeSeries) == 0 {
+		return nil, fmt.Errorf("alpha_vantage: no historical data for symbol %s", symbol)
+	}
+
+	return c.parseTimeSeries(result.TimeSeries, from, to), nil
+}
+
+// SupportsSymbol returns true for US stock/ETF symbols.
+// Alpha Vantage supports global stocks but we focus on US markets.
+func (c *AlphaVantageClient) SupportsSymbol(symbol string) bool {
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return false
+	}
+	// Basic validation: 1-5 uppercase letters, optionally with exchange suffix
+	// Examples: AAPL, MSFT, BRK.B, TSCO.LON
+	// For now, support all non-empty symbols
+	return len(symbol) >= 1 && len(symbol) <= 10
+}
+
+// Name returns the provider name.
+func (c *AlphaVantageClient) Name() string {
+	return "alpha_vantage"
+}
+
+// parseGlobalQuote converts Alpha Vantage response to domain Quote.
+func (c *AlphaVantageClient) parseGlobalQuote(data *globalQuoteData) (*services.Quote, error) {
+	price, err := strconv.ParseFloat(data.Price, 64)
+	if err != nil {
+		return nil, fmt.Errorf("alpha_vantage: parse price: %w", err)
+	}
+
+	change, _ := strconv.ParseFloat(data.Change, 64)
+
+	// Parse change percent (remove % suffix)
+	changePercentStr := strings.TrimSuffix(data.ChangePercent, "%")
+	changePercent, _ := strconv.ParseFloat(changePercentStr, 64)
+
+	// Determine market state based on time
+	marketState := c.determineMarketState()
+
+	return &services.Quote{
+		Symbol:        data.Symbol,
+		Price:         price,
+		Change:        change,
+		ChangePercent: changePercent,
+		MarketState:   marketState,
+		Currency:      "USD", // Alpha Vantage returns US stocks in USD
+		UpdatedAt:     time.Now().UTC(),
+		Source:        c.Name(),
+	}, nil
+}
+
+// parseTimeSeries converts Alpha Vantage time series to domain PricePoints.
+func (c *AlphaVantageClient) parseTimeSeries(timeSeries map[string]dailyOHLCVData, from, to time.Time) []services.PricePoint {
+	var points []services.PricePoint
+
+	for dateStr, data := range timeSeries {
+		// Parse date (format: 2024-01-15)
+		date, err := time.Parse("2006-01-02", dateStr)
+		if err != nil {
+			continue // skip invalid dates
+		}
+
+		// Filter by date range
+		if date.Before(from) || date.After(to) {
+			continue
+		}
+
+		open, _ := strconv.ParseFloat(data.Open, 64)
+		high, _ := strconv.ParseFloat(data.High, 64)
+		low, _ := strconv.ParseFloat(data.Low, 64)
+		closePrice, _ := strconv.ParseFloat(data.Close, 64)
+		volume, _ := strconv.ParseInt(data.Volume, 10, 64)
+
+		points = append(points, services.PricePoint{
+			Timestamp: date,
+			Open:      open,
+			High:      high,
+			Low:       low,
+			Close:     closePrice,
+			Volume:    volume,
+		})
+	}
+
+	return points
+}
+
+// determineMarketState returns the current US market state based on time.
+func (c *AlphaVantageClient) determineMarketState() string {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return "UNKNOWN"
+	}
+
+	now := time.Now().In(loc)
+	weekday := now.Weekday()
+	hour := now.Hour()
+	minute := now.Minute()
+
+	// Weekend
+	if weekday == time.Saturday || weekday == time.Sunday {
+		return "CLOSED"
+	}
+
+	// Market hours: 9:30 AM - 4:00 PM ET
+	marketOpen := hour > 9 || (hour == 9 && minute >= 30)
+	marketClose := hour < 16
+
+	if marketOpen && marketClose {
+		return "REGULAR"
+	}
+
+	// Pre-market: 4:00 AM - 9:30 AM ET
+	if hour >= 4 && (hour < 9 || (hour == 9 && minute < 30)) {
+		return "PRE"
+	}
+
+	// Post-market: 4:00 PM - 8:00 PM ET
+	if hour >= 16 && hour < 20 {
+		return "POST"
+	}
+
+	return "CLOSED"
+}

--- a/backend/internal/infrastructure/marketdata/alpha_vantage_client_test.go
+++ b/backend/internal/infrastructure/marketdata/alpha_vantage_client_test.go
@@ -1,0 +1,297 @@
+package marketdata
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlphaVantageClient_GetQuote(t *testing.T) {
+	// Mock Alpha Vantage API response
+	mockResponse := `{
+		"Global Quote": {
+			"01. symbol": "AAPL",
+			"02. open": "182.4300",
+			"03. high": "183.3100",
+			"04. low": "181.5600",
+			"05. price": "182.7500",
+			"06. volume": "3245678",
+			"07. latest trading day": "2024-01-15",
+			"08. previous close": "181.9400",
+			"09. change": "0.8100",
+			"10. change percent": "0.4454%"
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GLOBAL_QUOTE", r.URL.Query().Get("function"))
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+		assert.Equal(t, "test-api-key", r.URL.Query().Get("apikey"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "AAPL")
+
+	require.NoError(t, err)
+	require.NotNil(t, quote)
+	assert.Equal(t, "AAPL", quote.Symbol)
+	assert.Equal(t, 182.75, quote.Price)
+	assert.Equal(t, 0.81, quote.Change)
+	assert.InDelta(t, 0.4454, quote.ChangePercent, 0.001)
+	assert.Equal(t, "USD", quote.Currency)
+	assert.Equal(t, "alpha_vantage", quote.Source)
+}
+
+func TestAlphaVantageClient_GetQuote_EmptySymbol(t *testing.T) {
+	client := NewAlphaVantageClient("test-api-key", nil)
+	ctx := context.Background()
+
+	quote, err := client.GetQuote(ctx, "")
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "empty symbol")
+}
+
+func TestAlphaVantageClient_GetQuote_NoData(t *testing.T) {
+	// Empty response (API limit or invalid symbol)
+	mockResponse := `{"Global Quote": {}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "INVALID")
+
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "no data for symbol")
+}
+
+func TestAlphaVantageClient_GetQuote_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "AAPL")
+
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "unexpected status 500")
+}
+
+func TestAlphaVantageClient_GetQuotes(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		symbol := r.URL.Query().Get("symbol")
+
+		var response string
+		switch symbol {
+		case "AAPL":
+			response = `{"Global Quote": {"01. symbol": "AAPL", "05. price": "182.75", "09. change": "0.81", "10. change percent": "0.45%"}}`
+		case "MSFT":
+			response = `{"Global Quote": {"01. symbol": "MSFT", "05. price": "380.50", "09. change": "2.30", "10. change percent": "0.61%"}}`
+		default:
+			response = `{"Global Quote": {}}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quotes, err := client.GetQuotes(ctx, []string{"AAPL", "MSFT", "INVALID"})
+
+	require.NoError(t, err)
+	assert.Len(t, quotes, 2) // INVALID should be skipped
+	assert.Equal(t, 3, callCount)
+
+	assert.NotNil(t, quotes["AAPL"])
+	assert.Equal(t, 182.75, quotes["AAPL"].Price)
+
+	assert.NotNil(t, quotes["MSFT"])
+	assert.Equal(t, 380.50, quotes["MSFT"].Price)
+}
+
+func TestAlphaVantageClient_GetHistoricalPrices(t *testing.T) {
+	mockResponse := `{
+		"Meta Data": {
+			"1. Information": "Daily Prices",
+			"2. Symbol": "AAPL"
+		},
+		"Time Series (Daily)": {
+			"2024-01-15": {
+				"1. open": "182.00",
+				"2. high": "183.50",
+				"3. low": "181.00",
+				"4. close": "182.75",
+				"5. volume": "5000000"
+			},
+			"2024-01-14": {
+				"1. open": "180.00",
+				"2. high": "182.00",
+				"3. low": "179.50",
+				"4. close": "181.94",
+				"5. volume": "4500000"
+			},
+			"2024-01-10": {
+				"1. open": "178.00",
+				"2. high": "180.00",
+				"3. low": "177.50",
+				"4. close": "179.00",
+				"5. volume": "4000000"
+			}
+		}
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "TIME_SERIES_DAILY", r.URL.Query().Get("function"))
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	from := time.Date(2024, 1, 12, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC)
+
+	prices, err := client.GetHistoricalPrices(ctx, "AAPL", from, to)
+
+	require.NoError(t, err)
+	assert.Len(t, prices, 2) // Only 2024-01-14 and 2024-01-15 are in range (2024-01-10 is before)
+
+	// Check one of the prices
+	found := false
+	for _, p := range prices {
+		if p.Timestamp.Day() == 15 {
+			assert.Equal(t, 182.00, p.Open)
+			assert.Equal(t, 183.50, p.High)
+			assert.Equal(t, 181.00, p.Low)
+			assert.Equal(t, 182.75, p.Close)
+			assert.Equal(t, int64(5000000), p.Volume)
+			found = true
+		}
+	}
+	assert.True(t, found, "Expected to find price point for 2024-01-15")
+}
+
+func TestAlphaVantageClient_GetHistoricalPrices_NoData(t *testing.T) {
+	mockResponse := `{"Meta Data": {}, "Time Series (Daily)": {}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewAlphaVantageClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	prices, err := client.GetHistoricalPrices(ctx, "INVALID", time.Now().AddDate(0, -1, 0), time.Now())
+
+	assert.Error(t, err)
+	assert.Nil(t, prices)
+	assert.Contains(t, err.Error(), "no historical data")
+}
+
+func TestAlphaVantageClient_SupportsSymbol(t *testing.T) {
+	client := NewAlphaVantageClient("test-api-key", nil)
+
+	assert.True(t, client.SupportsSymbol("AAPL"))
+	assert.True(t, client.SupportsSymbol("MSFT"))
+	assert.True(t, client.SupportsSymbol("BRK.B"))
+	assert.True(t, client.SupportsSymbol("TSCO.LON"))
+	assert.False(t, client.SupportsSymbol(""))
+	assert.False(t, client.SupportsSymbol("   "))
+}
+
+func TestAlphaVantageClient_Name(t *testing.T) {
+	client := NewAlphaVantageClient("test-api-key", nil)
+	assert.Equal(t, "alpha_vantage", client.Name())
+}
+
+func TestAlphaVantageClient_WithRateLimiter(t *testing.T) {
+	mockResponse := `{"Global Quote": {"01. symbol": "AAPL", "05. price": "182.75", "09. change": "0.81", "10. change percent": "0.45%"}}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	rateLimiter := NewRateLimiter(2, time.Second)
+	client := NewAlphaVantageClient("test-api-key", rateLimiter)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+
+	// First two requests should succeed immediately
+	_, err1 := client.GetQuote(ctx, "AAPL")
+	_, err2 := client.GetQuote(ctx, "AAPL")
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+
+	// Third request should wait for rate limiter
+	start := time.Now()
+	_, err3 := client.GetQuote(ctx, "AAPL")
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err3)
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(400)) // Should have waited ~500ms
+}
+
+func TestAlphaVantageClient_RateLimiter_ContextCancelled(t *testing.T) {
+	rateLimiter := NewRateLimiter(1, time.Hour) // Very slow refill
+	client := NewAlphaVantageClient("test-api-key", rateLimiter)
+
+	// Consume the only token
+	rateLimiter.Allow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := client.GetQuote(ctx, "AAPL")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit wait")
+}

--- a/backend/internal/infrastructure/marketdata/finnhub_client.go
+++ b/backend/internal/infrastructure/marketdata/finnhub_client.go
@@ -1,0 +1,301 @@
+package marketdata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Unikyri/WealthScope/backend/internal/domain/services"
+)
+
+const (
+	finnhubBaseURL        = "https://finnhub.io/api/v1"
+	finnhubDefaultTimeout = 15 * time.Second
+)
+
+// FinnhubClient implements services.MarketDataClient for Finnhub API.
+// Uses /quote for current prices and /stock/candle for historical data.
+// Free tier: 60 requests/minute.
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type FinnhubClient struct {
+	httpClient  *http.Client
+	apiKey      string
+	baseURL     string
+	rateLimiter *RateLimiter
+}
+
+// NewFinnhubClient creates a new Finnhub client with the given API key.
+// If rateLimiter is nil, no rate limiting is applied.
+func NewFinnhubClient(apiKey string, rateLimiter *RateLimiter) *FinnhubClient {
+	return &FinnhubClient{
+		httpClient: &http.Client{
+			Timeout: finnhubDefaultTimeout,
+		},
+		apiKey:      apiKey,
+		baseURL:     finnhubBaseURL,
+		rateLimiter: rateLimiter,
+	}
+}
+
+// finnhubQuoteResponse represents the Finnhub /quote API response.
+type finnhubQuoteResponse struct {
+	CurrentPrice  float64 `json:"c"`  // Current price
+	Change        float64 `json:"d"`  // Change
+	PercentChange float64 `json:"dp"` // Percent change
+	High          float64 `json:"h"`  // High price of the day
+	Low           float64 `json:"l"`  // Low price of the day
+	Open          float64 `json:"o"`  // Open price of the day
+	PreviousClose float64 `json:"pc"` // Previous close price
+	Timestamp     int64   `json:"t"`  // Timestamp (Unix)
+}
+
+// finnhubCandleResponse represents the Finnhub /stock/candle API response.
+type finnhubCandleResponse struct {
+	Close     []float64 `json:"c"` // Close prices
+	High      []float64 `json:"h"` // High prices
+	Low       []float64 `json:"l"` // Low prices
+	Open      []float64 `json:"o"` // Open prices
+	Status    string    `json:"s"` // Status: "ok" or "no_data"
+	Timestamp []int64   `json:"t"` // Timestamps (Unix)
+	Volume    []int64   `json:"v"` // Volumes
+}
+
+// GetQuote fetches the latest quote for a symbol using /quote endpoint.
+func (c *FinnhubClient) GetQuote(ctx context.Context, symbol string) (*services.Quote, error) {
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("finnhub: rate limit wait: %w", err)
+		}
+	}
+
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, fmt.Errorf("finnhub: empty symbol")
+	}
+
+	url := fmt.Sprintf("%s/quote?symbol=%s&token=%s", c.baseURL, symbol, c.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("finnhub: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WealthScope/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("finnhub: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("finnhub: unexpected status %d", resp.StatusCode)
+	}
+
+	var result finnhubQuoteResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("finnhub: decode response: %w", err)
+	}
+
+	// Check for empty/invalid response (price == 0 and timestamp == 0)
+	if result.CurrentPrice == 0 && result.Timestamp == 0 {
+		return nil, fmt.Errorf("finnhub: no data for symbol %s", symbol)
+	}
+
+	return c.parseQuoteResponse(symbol, &result), nil
+}
+
+// GetQuotes fetches quotes for multiple symbols. Finnhub doesn't support batch quotes,
+// so this makes sequential calls for each symbol.
+func (c *FinnhubClient) GetQuotes(ctx context.Context, symbols []string) (map[string]*services.Quote, error) {
+	quotes := make(map[string]*services.Quote, len(symbols))
+
+	for _, symbol := range symbols {
+		select {
+		case <-ctx.Done():
+			return quotes, ctx.Err()
+		default:
+		}
+
+		q, err := c.GetQuote(ctx, symbol)
+		if err != nil {
+			// Skip failed symbols, don't fail entire batch
+			continue
+		}
+		quotes[strings.ToUpper(symbol)] = q
+	}
+
+	return quotes, nil
+}
+
+// GetHistoricalPrices fetches daily OHLCV data using /stock/candle endpoint.
+func (c *FinnhubClient) GetHistoricalPrices(ctx context.Context, symbol string, from, to time.Time) ([]services.PricePoint, error) {
+	if c.rateLimiter != nil {
+		if err := c.rateLimiter.Wait(ctx); err != nil {
+			return nil, fmt.Errorf("finnhub: rate limit wait: %w", err)
+		}
+	}
+
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return nil, fmt.Errorf("finnhub: empty symbol")
+	}
+
+	// Convert times to Unix timestamps
+	fromUnix := from.Unix()
+	toUnix := to.Unix()
+
+	// Resolution: D = daily candles
+	url := fmt.Sprintf("%s/stock/candle?symbol=%s&resolution=D&from=%d&to=%d&token=%s",
+		c.baseURL, symbol, fromUnix, toUnix, c.apiKey)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("finnhub: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", "WealthScope/1.0")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("finnhub: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("finnhub: unexpected status %d", resp.StatusCode)
+	}
+
+	var result finnhubCandleResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("finnhub: decode response: %w", err)
+	}
+
+	// Check for no data
+	if result.Status == "no_data" || len(result.Close) == 0 {
+		return nil, fmt.Errorf("finnhub: no historical data for symbol %s", symbol)
+	}
+
+	return c.parseCandleResponse(&result), nil
+}
+
+// SupportsSymbol returns true for US stock/ETF symbols.
+// Finnhub supports US stocks, forex, and crypto.
+func (c *FinnhubClient) SupportsSymbol(symbol string) bool {
+	symbol = strings.ToUpper(strings.TrimSpace(symbol))
+	if symbol == "" {
+		return false
+	}
+	// Basic validation: 1-5 uppercase letters for US stocks
+	// Finnhub uses plain symbols for US stocks (AAPL, MSFT)
+	return len(symbol) >= 1 && len(symbol) <= 10
+}
+
+// Name returns the provider name.
+func (c *FinnhubClient) Name() string {
+	return "finnhub"
+}
+
+// parseQuoteResponse converts Finnhub quote response to domain Quote.
+func (c *FinnhubClient) parseQuoteResponse(symbol string, data *finnhubQuoteResponse) *services.Quote {
+	var updatedAt time.Time
+	if data.Timestamp > 0 {
+		updatedAt = time.Unix(data.Timestamp, 0).UTC()
+	} else {
+		updatedAt = time.Now().UTC()
+	}
+
+	// Determine market state based on time
+	marketState := c.determineMarketState()
+
+	return &services.Quote{
+		Symbol:        symbol,
+		Price:         data.CurrentPrice,
+		Change:        data.Change,
+		ChangePercent: data.PercentChange,
+		MarketState:   marketState,
+		Currency:      "USD", // Finnhub returns US stocks in USD
+		UpdatedAt:     updatedAt,
+		Source:        c.Name(),
+	}
+}
+
+// parseCandleResponse converts Finnhub candle response to domain PricePoints.
+func (c *FinnhubClient) parseCandleResponse(data *finnhubCandleResponse) []services.PricePoint {
+	n := len(data.Timestamp)
+	points := make([]services.PricePoint, 0, n)
+
+	for i := 0; i < n; i++ {
+		var volume int64
+		if i < len(data.Volume) {
+			volume = data.Volume[i]
+		}
+
+		var open, high, low, closePrice float64
+		if i < len(data.Open) {
+			open = data.Open[i]
+		}
+		if i < len(data.High) {
+			high = data.High[i]
+		}
+		if i < len(data.Low) {
+			low = data.Low[i]
+		}
+		if i < len(data.Close) {
+			closePrice = data.Close[i]
+		}
+
+		points = append(points, services.PricePoint{
+			Timestamp: time.Unix(data.Timestamp[i], 0).UTC(),
+			Open:      open,
+			High:      high,
+			Low:       low,
+			Close:     closePrice,
+			Volume:    volume,
+		})
+	}
+
+	return points
+}
+
+// determineMarketState returns the current US market state based on time.
+func (c *FinnhubClient) determineMarketState() string {
+	loc, err := time.LoadLocation("America/New_York")
+	if err != nil {
+		return "UNKNOWN"
+	}
+
+	now := time.Now().In(loc)
+	weekday := now.Weekday()
+	hour := now.Hour()
+	minute := now.Minute()
+
+	// Weekend
+	if weekday == time.Saturday || weekday == time.Sunday {
+		return "CLOSED"
+	}
+
+	// Market hours: 9:30 AM - 4:00 PM ET
+	marketOpen := hour > 9 || (hour == 9 && minute >= 30)
+	marketClose := hour < 16
+
+	if marketOpen && marketClose {
+		return "REGULAR"
+	}
+
+	// Pre-market: 4:00 AM - 9:30 AM ET
+	if hour >= 4 && (hour < 9 || (hour == 9 && minute < 30)) {
+		return "PRE"
+	}
+
+	// Post-market: 4:00 PM - 8:00 PM ET
+	if hour >= 16 && hour < 20 {
+		return "POST"
+	}
+
+	return "CLOSED"
+}

--- a/backend/internal/infrastructure/marketdata/finnhub_client_test.go
+++ b/backend/internal/infrastructure/marketdata/finnhub_client_test.go
@@ -1,0 +1,317 @@
+package marketdata
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFinnhubClient_GetQuote(t *testing.T) {
+	// Mock Finnhub API response
+	mockResponse := `{
+		"c": 182.75,
+		"d": 0.81,
+		"dp": 0.4454,
+		"h": 183.31,
+		"l": 181.56,
+		"o": 182.43,
+		"pc": 181.94,
+		"t": 1705340800
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/quote", r.URL.Path)
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+		assert.Equal(t, "test-api-key", r.URL.Query().Get("token"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "AAPL")
+
+	require.NoError(t, err)
+	require.NotNil(t, quote)
+	assert.Equal(t, "AAPL", quote.Symbol)
+	assert.Equal(t, 182.75, quote.Price)
+	assert.Equal(t, 0.81, quote.Change)
+	assert.InDelta(t, 0.4454, quote.ChangePercent, 0.001)
+	assert.Equal(t, "USD", quote.Currency)
+	assert.Equal(t, "finnhub", quote.Source)
+	// Check that timestamp was parsed correctly
+	assert.Equal(t, time.Unix(1705340800, 0).UTC(), quote.UpdatedAt)
+}
+
+func TestFinnhubClient_GetQuote_EmptySymbol(t *testing.T) {
+	client := NewFinnhubClient("test-api-key", nil)
+	ctx := context.Background()
+
+	quote, err := client.GetQuote(ctx, "")
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "empty symbol")
+}
+
+func TestFinnhubClient_GetQuote_NoData(t *testing.T) {
+	// Empty response (invalid symbol)
+	mockResponse := `{"c": 0, "d": null, "dp": null, "h": 0, "l": 0, "o": 0, "pc": 0, "t": 0}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "INVALID")
+
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "no data for symbol")
+}
+
+func TestFinnhubClient_GetQuote_HTTPError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quote, err := client.GetQuote(ctx, "AAPL")
+
+	assert.Error(t, err)
+	assert.Nil(t, quote)
+	assert.Contains(t, err.Error(), "unexpected status 401")
+}
+
+func TestFinnhubClient_GetQuotes(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		symbol := r.URL.Query().Get("symbol")
+
+		var response string
+		switch symbol {
+		case "AAPL":
+			response = `{"c": 182.75, "d": 0.81, "dp": 0.45, "h": 183.0, "l": 181.0, "o": 182.0, "pc": 181.94, "t": 1705340800}`
+		case "MSFT":
+			response = `{"c": 380.50, "d": 2.30, "dp": 0.61, "h": 382.0, "l": 378.0, "o": 379.0, "pc": 378.20, "t": 1705340800}`
+		default:
+			response = `{"c": 0, "d": null, "dp": null, "h": 0, "l": 0, "o": 0, "pc": 0, "t": 0}`
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	quotes, err := client.GetQuotes(ctx, []string{"AAPL", "MSFT", "INVALID"})
+
+	require.NoError(t, err)
+	assert.Len(t, quotes, 2) // INVALID should be skipped
+	assert.Equal(t, 3, callCount)
+
+	assert.NotNil(t, quotes["AAPL"])
+	assert.Equal(t, 182.75, quotes["AAPL"].Price)
+
+	assert.NotNil(t, quotes["MSFT"])
+	assert.Equal(t, 380.50, quotes["MSFT"].Price)
+}
+
+func TestFinnhubClient_GetHistoricalPrices(t *testing.T) {
+	mockResponse := `{
+		"c": [182.75, 181.94, 180.50],
+		"h": [183.50, 182.50, 181.00],
+		"l": [181.00, 180.50, 179.00],
+		"o": [182.00, 181.00, 180.00],
+		"s": "ok",
+		"t": [1705363200, 1705276800, 1705190400],
+		"v": [5000000, 4500000, 4000000]
+	}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/stock/candle", r.URL.Path)
+		assert.Equal(t, "AAPL", r.URL.Query().Get("symbol"))
+		assert.Equal(t, "D", r.URL.Query().Get("resolution"))
+		assert.NotEmpty(t, r.URL.Query().Get("from"))
+		assert.NotEmpty(t, r.URL.Query().Get("to"))
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	from := time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC)
+
+	prices, err := client.GetHistoricalPrices(ctx, "AAPL", from, to)
+
+	require.NoError(t, err)
+	assert.Len(t, prices, 3)
+
+	// Check first price point
+	assert.Equal(t, 182.00, prices[0].Open)
+	assert.Equal(t, 183.50, prices[0].High)
+	assert.Equal(t, 181.00, prices[0].Low)
+	assert.Equal(t, 182.75, prices[0].Close)
+	assert.Equal(t, int64(5000000), prices[0].Volume)
+}
+
+func TestFinnhubClient_GetHistoricalPrices_NoData(t *testing.T) {
+	mockResponse := `{"s": "no_data"}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	prices, err := client.GetHistoricalPrices(ctx, "INVALID", time.Now().AddDate(0, -1, 0), time.Now())
+
+	assert.Error(t, err)
+	assert.Nil(t, prices)
+	assert.Contains(t, err.Error(), "no historical data")
+}
+
+func TestFinnhubClient_GetHistoricalPrices_EmptyArrays(t *testing.T) {
+	mockResponse := `{"c": [], "h": [], "l": [], "o": [], "s": "ok", "t": [], "v": []}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	prices, err := client.GetHistoricalPrices(ctx, "AAPL", time.Now().AddDate(0, -1, 0), time.Now())
+
+	assert.Error(t, err)
+	assert.Nil(t, prices)
+	assert.Contains(t, err.Error(), "no historical data")
+}
+
+func TestFinnhubClient_SupportsSymbol(t *testing.T) {
+	client := NewFinnhubClient("test-api-key", nil)
+
+	assert.True(t, client.SupportsSymbol("AAPL"))
+	assert.True(t, client.SupportsSymbol("MSFT"))
+	assert.True(t, client.SupportsSymbol("BRK.B"))
+	assert.False(t, client.SupportsSymbol(""))
+	assert.False(t, client.SupportsSymbol("   "))
+}
+
+func TestFinnhubClient_Name(t *testing.T) {
+	client := NewFinnhubClient("test-api-key", nil)
+	assert.Equal(t, "finnhub", client.Name())
+}
+
+func TestFinnhubClient_WithRateLimiter(t *testing.T) {
+	mockResponse := `{"c": 182.75, "d": 0.81, "dp": 0.45, "h": 183.0, "l": 181.0, "o": 182.0, "pc": 181.94, "t": 1705340800}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	rateLimiter := NewRateLimiter(2, time.Second)
+	client := NewFinnhubClient("test-api-key", rateLimiter)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+
+	// First two requests should succeed immediately
+	_, err1 := client.GetQuote(ctx, "AAPL")
+	_, err2 := client.GetQuote(ctx, "AAPL")
+
+	assert.NoError(t, err1)
+	assert.NoError(t, err2)
+
+	// Third request should wait for rate limiter
+	start := time.Now()
+	_, err3 := client.GetQuote(ctx, "AAPL")
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err3)
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(400)) // Should have waited ~500ms
+}
+
+func TestFinnhubClient_RateLimiter_ContextCancelled(t *testing.T) {
+	rateLimiter := NewRateLimiter(1, time.Hour) // Very slow refill
+	client := NewFinnhubClient("test-api-key", rateLimiter)
+
+	// Consume the only token
+	rateLimiter.Allow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := client.GetQuote(ctx, "AAPL")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limit wait")
+}
+
+func TestFinnhubClient_GetQuote_ZeroTimestamp(t *testing.T) {
+	// Response with zero timestamp (should use current time)
+	mockResponse := `{"c": 182.75, "d": 0.81, "dp": 0.45, "h": 183.0, "l": 181.0, "o": 182.0, "pc": 181.94, "t": 0}`
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(mockResponse))
+	}))
+	defer server.Close()
+
+	client := NewFinnhubClient("test-api-key", nil)
+	client.baseURL = server.URL
+
+	ctx := context.Background()
+	before := time.Now().UTC()
+	quote, err := client.GetQuote(ctx, "AAPL")
+	after := time.Now().UTC()
+
+	require.NoError(t, err)
+	require.NotNil(t, quote)
+	assert.Equal(t, 182.75, quote.Price)
+	// With t=0 but c!=0, it's valid data, UpdatedAt should be set to now
+	assert.True(t, quote.UpdatedAt.After(before.Add(-time.Second)) && quote.UpdatedAt.Before(after.Add(time.Second)))
+}

--- a/backend/internal/infrastructure/marketdata/rate_limiter.go
+++ b/backend/internal/infrastructure/marketdata/rate_limiter.go
@@ -1,0 +1,104 @@
+package marketdata
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// RateLimiter implements a token bucket rate limiter for API calls.
+// It allows bursting up to maxTokens requests and refills tokens over time.
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type RateLimiter struct {
+	maxTokens  int
+	tokens     int
+	refillRate time.Duration // duration per token refill
+	lastRefill time.Time
+	mu         sync.Mutex
+}
+
+// NewRateLimiter creates a new rate limiter with the given max tokens and refill period.
+// maxTokens: maximum number of tokens (requests) allowed in the bucket
+// refillPeriod: time period over which all tokens are refilled (e.g., time.Minute for 60 req/min)
+func NewRateLimiter(maxTokens int, refillPeriod time.Duration) *RateLimiter {
+	if maxTokens <= 0 {
+		maxTokens = 1
+	}
+	refillRate := refillPeriod / time.Duration(maxTokens)
+	return &RateLimiter{
+		maxTokens:  maxTokens,
+		tokens:     maxTokens,
+		refillRate: refillRate,
+		lastRefill: time.Now(),
+	}
+}
+
+// refill adds tokens based on elapsed time since last refill.
+// Must be called with mutex held.
+func (r *RateLimiter) refill() {
+	now := time.Now()
+	elapsed := now.Sub(r.lastRefill)
+	tokensToAdd := int(elapsed / r.refillRate)
+	if tokensToAdd > 0 {
+		r.tokens += tokensToAdd
+		if r.tokens > r.maxTokens {
+			r.tokens = r.maxTokens
+		}
+		r.lastRefill = now
+	}
+}
+
+// Allow checks if a request is allowed (non-blocking).
+// Returns true if allowed (and consumes a token), false otherwise.
+func (r *RateLimiter) Allow() bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.refill()
+
+	if r.tokens > 0 {
+		r.tokens--
+		return true
+	}
+	return false
+}
+
+// Wait blocks until a token is available or the context is canceled.
+// Returns nil if a token was acquired, or the context error if canceled.
+func (r *RateLimiter) Wait(ctx context.Context) error {
+	for {
+		if r.Allow() {
+			return nil
+		}
+
+		// Calculate time until next token
+		r.mu.Lock()
+		waitTime := r.refillRate
+		r.mu.Unlock()
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(waitTime):
+			// Try again
+		}
+	}
+}
+
+// Tokens returns the current number of available tokens.
+// Useful for monitoring and testing.
+func (r *RateLimiter) Tokens() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.refill()
+	return r.tokens
+}
+
+// Reset resets the rate limiter to its initial state with full tokens.
+func (r *RateLimiter) Reset() {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.tokens = r.maxTokens
+	r.lastRefill = time.Now()
+}

--- a/backend/internal/infrastructure/marketdata/rate_limiter_test.go
+++ b/backend/internal/infrastructure/marketdata/rate_limiter_test.go
@@ -1,0 +1,146 @@
+package marketdata
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewRateLimiter(t *testing.T) {
+	rl := NewRateLimiter(10, time.Minute)
+	require.NotNil(t, rl)
+	assert.Equal(t, 10, rl.maxTokens)
+	assert.Equal(t, 10, rl.tokens)
+}
+
+func TestNewRateLimiter_ZeroTokens(t *testing.T) {
+	rl := NewRateLimiter(0, time.Minute)
+	require.NotNil(t, rl)
+	assert.Equal(t, 1, rl.maxTokens) // should default to 1
+}
+
+func TestRateLimiter_Allow(t *testing.T) {
+	rl := NewRateLimiter(3, time.Minute)
+
+	// Should allow 3 requests
+	assert.True(t, rl.Allow())
+	assert.True(t, rl.Allow())
+	assert.True(t, rl.Allow())
+
+	// Fourth request should be denied
+	assert.False(t, rl.Allow())
+}
+
+func TestRateLimiter_Tokens(t *testing.T) {
+	rl := NewRateLimiter(5, time.Minute)
+
+	assert.Equal(t, 5, rl.Tokens())
+
+	rl.Allow()
+	assert.Equal(t, 4, rl.Tokens())
+
+	rl.Allow()
+	rl.Allow()
+	assert.Equal(t, 2, rl.Tokens())
+}
+
+func TestRateLimiter_Reset(t *testing.T) {
+	rl := NewRateLimiter(5, time.Minute)
+
+	// Consume all tokens
+	for i := 0; i < 5; i++ {
+		rl.Allow()
+	}
+	assert.Equal(t, 0, rl.Tokens())
+
+	// Reset
+	rl.Reset()
+	assert.Equal(t, 5, rl.Tokens())
+}
+
+func TestRateLimiter_Refill(t *testing.T) {
+	// Create a rate limiter with 10 tokens per 100ms (fast refill for testing)
+	rl := NewRateLimiter(10, 100*time.Millisecond)
+
+	// Consume all tokens
+	for i := 0; i < 10; i++ {
+		require.True(t, rl.Allow())
+	}
+	assert.False(t, rl.Allow())
+
+	// Wait for refill (at least 1 token)
+	time.Sleep(15 * time.Millisecond) // ~1.5 tokens should refill
+
+	// Should have at least 1 token now
+	assert.True(t, rl.Allow())
+}
+
+func TestRateLimiter_Wait_Success(t *testing.T) {
+	// Fast rate limiter for testing
+	rl := NewRateLimiter(2, 50*time.Millisecond)
+
+	// Consume all tokens
+	rl.Allow()
+	rl.Allow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	start := time.Now()
+	err := rl.Wait(ctx)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, elapsed.Milliseconds(), int64(20)) // should have waited for refill
+}
+
+func TestRateLimiter_Wait_ContextCancelled(t *testing.T) {
+	rl := NewRateLimiter(1, time.Hour) // very slow refill
+
+	// Consume the only token
+	rl.Allow()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	err := rl.Wait(ctx)
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestRateLimiter_Wait_ImmediateSuccess(t *testing.T) {
+	rl := NewRateLimiter(5, time.Minute)
+
+	ctx := context.Background()
+	start := time.Now()
+	err := rl.Wait(ctx)
+	elapsed := time.Since(start)
+
+	assert.NoError(t, err)
+	assert.Less(t, elapsed.Milliseconds(), int64(10)) // should be nearly instant
+	assert.Equal(t, 4, rl.Tokens())                   // one token consumed
+}
+
+func TestRateLimiter_ConcurrentAccess(t *testing.T) {
+	rl := NewRateLimiter(100, time.Second)
+
+	// Run 50 goroutines trying to acquire tokens
+	done := make(chan bool, 50)
+	for i := 0; i < 50; i++ {
+		go func() {
+			rl.Allow()
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 50; i++ {
+		<-done
+	}
+
+	// Should have 50 tokens remaining
+	assert.Equal(t, 50, rl.Tokens())
+}


### PR DESCRIPTION
## Summary

- Implement **AlphaVantageClient** for US stock/ETF data using GLOBAL_QUOTE and TIME_SERIES_DAILY endpoints
- Implement **FinnhubClient** for real-time quotes using /quote and /stock/candle endpoints
- Add **RateLimiter** with token bucket algorithm to respect API rate limits
- Configure provider fallback order: Yahoo Finance (primary) -> Finnhub -> Alpha Vantage

## Changes

### New Files
- `alpha_vantage_client.go` - Alpha Vantage API client implementation
- `finnhub_client.go` - Finnhub API client implementation
- `rate_limiter.go` - Token bucket rate limiter
- Unit tests for all new components (46 tests passing)

### Modified Files
- `config.go` - Added MarketDataConfig with API keys, enabled flags, and rate limits
- `server.go` - Added `setupMarketDataProviders()` with fallback logic
- `.env.example` - Documented new environment variables

## Rate Limits Configured

| Provider | Free Tier Limit | Configured |
|----------|-----------------|------------|
| Yahoo Finance | No official limit | 100 req/min |
| Finnhub | 60 req/min | 60 req/min |
| Alpha Vantage | 25 req/day | 5 req/min (conservative) |

## Test Plan

- [x] All unit tests pass (`go test ./...`)
- [x] Linter passes (`golangci-lint run ./...`)
- [x] Code formatted (`gofmt -w .`)

## Related

- Continues from US-6.1 Market Data Abstraction Layer (#297)