### PR TITLE
feat(US-7.4): What-If Scenario Simulator Backend

### DIFF
--- a/backend/internal/application/services/historical_analyzer.go
+++ b/backend/internal/application/services/historical_analyzer.go
@@ -1,0 +1,312 @@
+package services
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"go.uber.org/zap"
+
+	"github.com/Unikyri/WealthScope/backend/internal/domain/entities"
+	"github.com/Unikyri/WealthScope/backend/internal/domain/repositories"
+)
+
+// HistoricalStats contains statistical analysis of historical price data
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type HistoricalStats struct {
+	Symbol        string  `json:"symbol"`
+	Period        string  `json:"period"`
+	DataPoints    int     `json:"data_points"`
+	AverageReturn float64 `json:"average_return"`
+	Volatility    float64 `json:"volatility"`
+	MaxDrawdown   float64 `json:"max_drawdown"`
+	BestDay       float64 `json:"best_day"`
+	WorstDay      float64 `json:"worst_day"`
+	PositiveDays  int     `json:"positive_days"`
+	NegativeDays  int     `json:"negative_days"`
+}
+
+// Projection contains future value projections based on historical data
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type Projection struct {
+	Symbol             string  `json:"symbol"`
+	CurrentValue       float64 `json:"current_value"`
+	TimeframeMonths    int     `json:"timeframe_months"`
+	ExpectedValue      float64 `json:"expected_value"`
+	OptimisticValue    float64 `json:"optimistic_value"`
+	PessimisticValue   float64 `json:"pessimistic_value"`
+	ExpectedReturn     float64 `json:"expected_return"`
+	OptimisticReturn   float64 `json:"optimistic_return"`
+	PessimisticReturn  float64 `json:"pessimistic_return"`
+	ConfidenceInterval float64 `json:"confidence_interval"`
+}
+
+// HistoricalAnalyzer provides historical data analysis for scenario simulations
+type HistoricalAnalyzer struct {
+	priceHistoryRepo repositories.PriceHistoryRepository
+	logger           *zap.Logger
+}
+
+// NewHistoricalAnalyzer creates a new HistoricalAnalyzer
+func NewHistoricalAnalyzer(
+	priceHistoryRepo repositories.PriceHistoryRepository,
+	logger *zap.Logger,
+) *HistoricalAnalyzer {
+	return &HistoricalAnalyzer{
+		priceHistoryRepo: priceHistoryRepo,
+		logger:           logger,
+	}
+}
+
+// GetHistoricalStats returns statistical analysis for a symbol over a period
+func (a *HistoricalAnalyzer) GetHistoricalStats(
+	ctx context.Context,
+	symbol string,
+	period string,
+) (*HistoricalStats, error) {
+	// Parse period to date range
+	from, to := a.parsePeriod(period)
+
+	// Get historical prices
+	prices, err := a.priceHistoryRepo.GetBySymbolAndDateRange(ctx, symbol, from, to)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get price history: %w", err)
+	}
+
+	if len(prices) < 2 {
+		a.logger.Warn("insufficient data points for analysis",
+			zap.String("symbol", symbol),
+			zap.Int("data_points", len(prices)),
+		)
+		return &HistoricalStats{
+			Symbol:     symbol,
+			Period:     period,
+			DataPoints: len(prices),
+		}, nil
+	}
+
+	// Calculate returns
+	returns := a.calculateDailyReturns(prices)
+	if len(returns) == 0 {
+		return &HistoricalStats{
+			Symbol:     symbol,
+			Period:     period,
+			DataPoints: len(prices),
+		}, nil
+	}
+
+	// Calculate statistics
+	avgReturn := a.calculateMean(returns)
+	volatility := a.calculateStandardDeviation(returns)
+	maxDrawdown := a.calculateMaxDrawdown(prices)
+	bestDay, worstDay := a.findExtremes(returns)
+	positiveDays, negativeDays := a.countPositiveNegative(returns)
+
+	return &HistoricalStats{
+		Symbol:        symbol,
+		Period:        period,
+		DataPoints:    len(prices),
+		AverageReturn: avgReturn * 100,
+		Volatility:    volatility * 100,
+		MaxDrawdown:   maxDrawdown * 100,
+		BestDay:       bestDay * 100,
+		WorstDay:      worstDay * 100,
+		PositiveDays:  positiveDays,
+		NegativeDays:  negativeDays,
+	}, nil
+}
+
+// ProjectWithHistory projects future values based on historical performance
+func (a *HistoricalAnalyzer) ProjectWithHistory(
+	ctx context.Context,
+	symbol string,
+	currentValue float64,
+	months int,
+) (*Projection, error) {
+	// Get 1 year of historical data for projection
+	stats, err := a.GetHistoricalStats(ctx, symbol, "1Y")
+	if err != nil {
+		return nil, err
+	}
+
+	// If no data, return projection with current value
+	if stats.DataPoints < 2 {
+		return &Projection{
+			Symbol:             symbol,
+			CurrentValue:       currentValue,
+			TimeframeMonths:    months,
+			ExpectedValue:      currentValue,
+			OptimisticValue:    currentValue,
+			PessimisticValue:   currentValue,
+			ConfidenceInterval: 0,
+		}, nil
+	}
+
+	// Annualize the daily return (assume ~252 trading days)
+	dailyReturn := stats.AverageReturn / 100
+	annualReturn := dailyReturn * 252
+
+	// Scale to the requested timeframe
+	timeframeYears := float64(months) / 12.0
+	expectedReturn := annualReturn * timeframeYears
+
+	// Calculate volatility-adjusted projections
+	dailyVolatility := stats.Volatility / 100
+	annualVolatility := dailyVolatility * math.Sqrt(252)
+	timeframeVolatility := annualVolatility * math.Sqrt(timeframeYears)
+
+	// 1.5 standard deviations for ~87% confidence interval
+	confidenceMultiplier := 1.5
+
+	expectedValue := currentValue * (1 + expectedReturn)
+	optimisticValue := currentValue * (1 + expectedReturn + (timeframeVolatility * confidenceMultiplier))
+	pessimisticValue := currentValue * (1 + expectedReturn - (timeframeVolatility * confidenceMultiplier))
+
+	// Don't let pessimistic go below 0
+	if pessimisticValue < 0 {
+		pessimisticValue = 0
+	}
+
+	return &Projection{
+		Symbol:             symbol,
+		CurrentValue:       currentValue,
+		TimeframeMonths:    months,
+		ExpectedValue:      expectedValue,
+		OptimisticValue:    optimisticValue,
+		PessimisticValue:   pessimisticValue,
+		ExpectedReturn:     expectedReturn * 100,
+		OptimisticReturn:   ((optimisticValue - currentValue) / currentValue) * 100,
+		PessimisticReturn:  ((pessimisticValue - currentValue) / currentValue) * 100,
+		ConfidenceInterval: 87,
+	}, nil
+}
+
+// parsePeriod converts a period string to a date range
+func (a *HistoricalAnalyzer) parsePeriod(period string) (time.Time, time.Time) {
+	now := time.Now().UTC()
+	to := now
+
+	var from time.Time
+	switch period {
+	case "1M":
+		from = now.AddDate(0, -1, 0)
+	case "3M":
+		from = now.AddDate(0, -3, 0)
+	case "6M":
+		from = now.AddDate(0, -6, 0)
+	case "1Y":
+		from = now.AddDate(-1, 0, 0)
+	case "2Y":
+		from = now.AddDate(-2, 0, 0)
+	case "5Y":
+		from = now.AddDate(-5, 0, 0)
+	default:
+		// Default to 1 year
+		from = now.AddDate(-1, 0, 0)
+	}
+
+	return from, to
+}
+
+// calculateDailyReturns computes the daily returns from price data
+func (a *HistoricalAnalyzer) calculateDailyReturns(prices []entities.PriceHistory) []float64 {
+	if len(prices) < 2 {
+		return nil
+	}
+
+	returns := make([]float64, 0, len(prices)-1)
+	for i := 1; i < len(prices); i++ {
+		if prices[i-1].Price > 0 {
+			dailyReturn := (prices[i].Price - prices[i-1].Price) / prices[i-1].Price
+			returns = append(returns, dailyReturn)
+		}
+	}
+	return returns
+}
+
+// calculateMean computes the mean of a slice of values
+func (a *HistoricalAnalyzer) calculateMean(values []float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sum := 0.0
+	for _, v := range values {
+		sum += v
+	}
+	return sum / float64(len(values))
+}
+
+// calculateStandardDeviation computes the standard deviation
+func (a *HistoricalAnalyzer) calculateStandardDeviation(values []float64) float64 {
+	if len(values) < 2 {
+		return 0
+	}
+	mean := a.calculateMean(values)
+	sumSquaredDiff := 0.0
+	for _, v := range values {
+		diff := v - mean
+		sumSquaredDiff += diff * diff
+	}
+	variance := sumSquaredDiff / float64(len(values)-1)
+	return math.Sqrt(variance)
+}
+
+// calculateMaxDrawdown computes the maximum peak-to-trough decline
+func (a *HistoricalAnalyzer) calculateMaxDrawdown(prices []entities.PriceHistory) float64 {
+	if len(prices) < 2 {
+		return 0
+	}
+
+	maxDrawdown := 0.0
+	peak := prices[0].Price
+
+	for _, p := range prices {
+		if p.Price > peak {
+			peak = p.Price
+		}
+		if peak > 0 {
+			drawdown := (peak - p.Price) / peak
+			if drawdown > maxDrawdown {
+				maxDrawdown = drawdown
+			}
+		}
+	}
+
+	return maxDrawdown
+}
+
+// findExtremes finds the best and worst daily returns
+func (a *HistoricalAnalyzer) findExtremes(returns []float64) (best, worst float64) {
+	if len(returns) == 0 {
+		return 0, 0
+	}
+
+	best = returns[0]
+	worst = returns[0]
+
+	for _, r := range returns {
+		if r > best {
+			best = r
+		}
+		if r < worst {
+			worst = r
+		}
+	}
+
+	return best, worst
+}
+
+// countPositiveNegative counts positive and negative return days
+func (a *HistoricalAnalyzer) countPositiveNegative(returns []float64) (positive, negative int) {
+	for _, r := range returns {
+		if r > 0 {
+			positive++
+		} else if r < 0 {
+			negative++
+		}
+	}
+	return positive, negative
+}

--- a/backend/internal/application/services/scenario_engine.go
+++ b/backend/internal/application/services/scenario_engine.go
@@ -1,0 +1,476 @@
+package services
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"go.uber.org/zap"
+
+	"github.com/Unikyri/WealthScope/backend/internal/domain/entities"
+	"github.com/Unikyri/WealthScope/backend/internal/domain/repositories"
+)
+
+// ScenarioEngine runs portfolio simulations for what-if scenarios
+type ScenarioEngine struct {
+	assetRepo repositories.AssetRepository
+	logger    *zap.Logger
+}
+
+// NewScenarioEngine creates a new ScenarioEngine
+func NewScenarioEngine(
+	assetRepo repositories.AssetRepository,
+	logger *zap.Logger,
+) *ScenarioEngine {
+	return &ScenarioEngine{
+		assetRepo: assetRepo,
+		logger:    logger,
+	}
+}
+
+// Simulate runs a scenario and returns projected results
+func (e *ScenarioEngine) Simulate(ctx context.Context, req entities.ScenarioRequest) (*entities.ScenarioResult, error) {
+	e.logger.Info("running scenario simulation",
+		zap.String("user_id", req.UserID.String()),
+		zap.String("type", string(req.Type)),
+	)
+
+	// Validate scenario type
+	if !req.Type.IsValid() {
+		return nil, fmt.Errorf("invalid scenario type: %s", req.Type)
+	}
+
+	// Get current portfolio state
+	currentState, err := e.getCurrentState(ctx, req.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get current state: %w", err)
+	}
+
+	// Run appropriate simulation
+	var projectedState entities.PortfolioState
+	var changes []entities.ChangeDetail
+	var warnings []string
+
+	switch req.Type {
+	case entities.ScenarioBuyAsset:
+		projectedState, changes, warnings, err = e.simulateBuy(ctx, req.UserID, currentState, req.Parameters)
+	case entities.ScenarioSellAsset:
+		projectedState, changes, warnings, err = e.simulateSell(ctx, req.UserID, currentState, req.Parameters)
+	case entities.ScenarioMarketMove:
+		projectedState, changes, warnings, err = e.simulateMarketMove(currentState, req.Parameters)
+	case entities.ScenarioNewAsset:
+		projectedState, changes, warnings, err = e.simulateNewAsset(currentState, req.Parameters)
+	case entities.ScenarioRebalance:
+		projectedState, changes, warnings, err = e.simulateRebalance(currentState, req.Parameters)
+	default:
+		return nil, fmt.Errorf("unhandled scenario type: %s", req.Type)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &entities.ScenarioResult{
+		CurrentState:   currentState,
+		ProjectedState: projectedState,
+		Changes:        changes,
+		Warnings:       warnings,
+	}, nil
+}
+
+// getCurrentState builds the current portfolio state from the repository
+func (e *ScenarioEngine) getCurrentState(ctx context.Context, userID uuid.UUID) (entities.PortfolioState, error) {
+	summary, err := e.assetRepo.GetPortfolioSummary(ctx, userID)
+	if err != nil {
+		return entities.PortfolioState{}, err
+	}
+
+	allocation := make([]entities.AllocationItem, 0, len(summary.BreakdownByType))
+	for _, b := range summary.BreakdownByType {
+		allocation = append(allocation, entities.AllocationItem{
+			Type:    string(b.Type),
+			Value:   b.Value,
+			Percent: b.Percent,
+		})
+	}
+
+	return entities.PortfolioState{
+		TotalValue:      summary.TotalValue,
+		TotalInvested:   summary.TotalInvested,
+		GainLoss:        summary.GainLoss,
+		GainLossPercent: summary.GainLossPercent,
+		AssetCount:      summary.AssetCount,
+		Allocation:      allocation,
+	}, nil
+}
+
+// simulateBuy simulates buying more of an existing asset
+func (e *ScenarioEngine) simulateBuy(
+	ctx context.Context,
+	userID uuid.UUID,
+	current entities.PortfolioState,
+	params entities.ScenarioParams,
+) (entities.PortfolioState, []entities.ChangeDetail, []string, error) {
+	var warnings []string
+
+	// Validate parameters
+	if params.Quantity <= 0 {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("quantity must be positive")
+	}
+	if params.Price <= 0 {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("price must be positive")
+	}
+
+	// Calculate purchase amount
+	purchaseAmount := params.Quantity * params.Price
+	newTotalValue := current.TotalValue + purchaseAmount
+	newTotalInvested := current.TotalInvested + purchaseAmount
+
+	// If asset ID is provided, validate it exists
+	var assetName string
+	if params.AssetID != nil {
+		asset, findErr := e.assetRepo.FindByID(ctx, *params.AssetID, userID)
+		if findErr != nil {
+			return entities.PortfolioState{}, nil, nil, fmt.Errorf("asset not found: %w", findErr)
+		}
+		assetName = asset.Name
+	} else {
+		assetName = "asset"
+	}
+
+	projected := current
+	projected.TotalValue = newTotalValue
+	projected.TotalInvested = newTotalInvested
+	projected.GainLoss = newTotalValue - newTotalInvested
+	if newTotalInvested > 0 {
+		projected.GainLossPercent = (projected.GainLoss / newTotalInvested) * 100
+	}
+
+	changes := []entities.ChangeDetail{
+		{
+			Type:        "increase",
+			Description: fmt.Sprintf("Buy %.4f units of %s at $%.2f each", params.Quantity, assetName, params.Price),
+			OldValue:    current.TotalValue,
+			NewValue:    newTotalValue,
+			Difference:  purchaseAmount,
+		},
+	}
+
+	return projected, changes, warnings, nil
+}
+
+// simulateSell simulates selling an existing asset
+func (e *ScenarioEngine) simulateSell(
+	ctx context.Context,
+	userID uuid.UUID,
+	current entities.PortfolioState,
+	params entities.ScenarioParams,
+) (entities.PortfolioState, []entities.ChangeDetail, []string, error) {
+	var warnings []string
+
+	if params.Quantity <= 0 {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("quantity must be positive")
+	}
+	if params.AssetID == nil {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("asset_id is required for sell scenario")
+	}
+
+	// Get the asset
+	asset, findErr := e.assetRepo.FindByID(ctx, *params.AssetID, userID)
+	if findErr != nil {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("asset not found: %w", findErr)
+	}
+
+	if params.Quantity > asset.Quantity {
+		warnings = append(warnings, fmt.Sprintf("Selling more than owned: %.4f > %.4f", params.Quantity, asset.Quantity))
+	}
+
+	// Use current price if available, otherwise purchase price
+	price := asset.PurchasePrice
+	if asset.CurrentPrice != nil {
+		price = *asset.CurrentPrice
+	}
+
+	// Use provided price if specified
+	if params.Price > 0 {
+		price = params.Price
+	}
+
+	saleAmount := params.Quantity * price
+	costBasis := params.Quantity * asset.PurchasePrice
+
+	newTotalValue := current.TotalValue - saleAmount
+	newTotalInvested := current.TotalInvested - costBasis
+
+	projected := current
+	projected.TotalValue = newTotalValue
+	projected.TotalInvested = newTotalInvested
+	if newTotalInvested > 0 {
+		projected.GainLoss = newTotalValue - newTotalInvested
+		projected.GainLossPercent = (projected.GainLoss / newTotalInvested) * 100
+	} else {
+		projected.GainLoss = 0
+		projected.GainLossPercent = 0
+	}
+
+	// Adjust asset count if selling all
+	if params.Quantity >= asset.Quantity {
+		projected.AssetCount--
+	}
+
+	changes := []entities.ChangeDetail{
+		{
+			Type:        "decrease",
+			Description: fmt.Sprintf("Sell %.4f units of %s at $%.2f each", params.Quantity, asset.Name, price),
+			OldValue:    current.TotalValue,
+			NewValue:    newTotalValue,
+			Difference:  -saleAmount,
+		},
+	}
+
+	return projected, changes, warnings, nil
+}
+
+// simulateMarketMove simulates a market-wide or sector-specific change
+//
+//nolint:unparam // error is always nil but kept for interface consistency with other simulate methods
+func (e *ScenarioEngine) simulateMarketMove(
+	current entities.PortfolioState,
+	params entities.ScenarioParams,
+) (entities.PortfolioState, []entities.ChangeDetail, []string, error) {
+	var warnings []string
+
+	if params.ChangePercent == 0 {
+		warnings = append(warnings, "Change percent is 0, no impact on portfolio")
+	}
+
+	changeMultiplier := 1 + (params.ChangePercent / 100)
+
+	// If asset types are specified, only apply to those types
+	var affectedTypes []string
+	if len(params.AssetTypes) > 0 {
+		affectedTypes = params.AssetTypes
+	}
+
+	projected := current
+	var totalChange float64
+
+	if len(affectedTypes) > 0 {
+		// Selective change - only affect specified asset types
+		for i, alloc := range projected.Allocation {
+			isAffected := false
+			for _, t := range affectedTypes {
+				if alloc.Type == t {
+					isAffected = true
+					break
+				}
+			}
+			if isAffected {
+				oldValue := alloc.Value
+				newValue := oldValue * changeMultiplier
+				change := newValue - oldValue
+				totalChange += change
+				projected.Allocation[i].Value = newValue
+			}
+		}
+		projected.TotalValue = current.TotalValue + totalChange
+	} else {
+		// Apply to entire portfolio
+		projected.TotalValue = current.TotalValue * changeMultiplier
+		totalChange = projected.TotalValue - current.TotalValue
+		// Update all allocations
+		for i := range projected.Allocation {
+			projected.Allocation[i].Value *= changeMultiplier
+		}
+	}
+
+	// Recalculate gain/loss
+	projected.GainLoss = projected.TotalValue - current.TotalInvested
+	if current.TotalInvested > 0 {
+		projected.GainLossPercent = (projected.GainLoss / current.TotalInvested) * 100
+	}
+
+	// Recalculate allocation percentages
+	if projected.TotalValue > 0 {
+		for i := range projected.Allocation {
+			projected.Allocation[i].Percent = (projected.Allocation[i].Value / projected.TotalValue) * 100
+		}
+	}
+
+	changeType := "increase"
+	if params.ChangePercent < 0 {
+		changeType = "decrease"
+	}
+
+	description := fmt.Sprintf("Market moves %.1f%%", params.ChangePercent)
+	if len(affectedTypes) > 0 {
+		description = fmt.Sprintf("%s (affecting: %v)", description, affectedTypes)
+	}
+
+	changes := []entities.ChangeDetail{
+		{
+			Type:        changeType,
+			Description: description,
+			OldValue:    current.TotalValue,
+			NewValue:    projected.TotalValue,
+			Difference:  totalChange,
+		},
+	}
+
+	return projected, changes, warnings, nil
+}
+
+// simulateNewAsset simulates adding a new asset to the portfolio
+func (e *ScenarioEngine) simulateNewAsset(
+	current entities.PortfolioState,
+	params entities.ScenarioParams,
+) (entities.PortfolioState, []entities.ChangeDetail, []string, error) {
+	var warnings []string
+
+	if params.NewAsset == nil {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("new_asset parameters are required")
+	}
+
+	newAsset := params.NewAsset
+	if newAsset.Quantity <= 0 || newAsset.PurchasePrice <= 0 {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("quantity and purchase_price must be positive")
+	}
+
+	investmentAmount := newAsset.Quantity * newAsset.PurchasePrice
+
+	projected := current
+	projected.TotalValue += investmentAmount
+	projected.TotalInvested += investmentAmount
+	projected.AssetCount++
+	projected.GainLoss = projected.TotalValue - projected.TotalInvested
+	if projected.TotalInvested > 0 {
+		projected.GainLossPercent = (projected.GainLoss / projected.TotalInvested) * 100
+	}
+
+	// Update allocation
+	assetType := newAsset.Type
+	found := false
+	for i := range projected.Allocation {
+		if projected.Allocation[i].Type == assetType {
+			projected.Allocation[i].Value += investmentAmount
+			found = true
+			break
+		}
+	}
+	if !found {
+		projected.Allocation = append(projected.Allocation, entities.AllocationItem{
+			Type:  assetType,
+			Value: investmentAmount,
+		})
+	}
+
+	// Recalculate percentages
+	if projected.TotalValue > 0 {
+		for i := range projected.Allocation {
+			projected.Allocation[i].Percent = (projected.Allocation[i].Value / projected.TotalValue) * 100
+		}
+	}
+
+	changes := []entities.ChangeDetail{
+		{
+			Type:        "new",
+			Description: fmt.Sprintf("Add new %s: %s (%.4f units at $%.2f)", newAsset.Type, newAsset.Name, newAsset.Quantity, newAsset.PurchasePrice),
+			NewValue:    investmentAmount,
+			Difference:  investmentAmount,
+		},
+	}
+
+	return projected, changes, warnings, nil
+}
+
+// simulateRebalance simulates rebalancing to a target allocation
+func (e *ScenarioEngine) simulateRebalance(
+	current entities.PortfolioState,
+	params entities.ScenarioParams,
+) (entities.PortfolioState, []entities.ChangeDetail, []string, error) {
+	var warnings []string
+
+	if len(params.TargetAllocation) == 0 {
+		return entities.PortfolioState{}, nil, nil, fmt.Errorf("target_allocation is required for rebalance scenario")
+	}
+
+	// Validate target allocation sums to 100
+	totalPercent := 0.0
+	for _, pct := range params.TargetAllocation {
+		totalPercent += pct
+	}
+	if totalPercent < 99 || totalPercent > 101 {
+		warnings = append(warnings, fmt.Sprintf("Target allocation sums to %.1f%%, ideally should be 100%%", totalPercent))
+	}
+
+	projected := current
+	var changes []entities.ChangeDetail
+
+	// Calculate target values for each type
+	for assetType, targetPct := range params.TargetAllocation {
+		targetValue := current.TotalValue * (targetPct / 100)
+
+		// Find current value for this type
+		var currentValue float64
+		for _, alloc := range current.Allocation {
+			if alloc.Type == assetType {
+				currentValue = alloc.Value
+				break
+			}
+		}
+
+		diff := targetValue - currentValue
+		if diff > 0.01 || diff < -0.01 { // Ignore tiny differences
+			changeType := "increase"
+			action := "Buy"
+			if diff < 0 {
+				changeType = "decrease"
+				action = "Sell"
+			}
+
+			changes = append(changes, entities.ChangeDetail{
+				Type:        changeType,
+				Description: fmt.Sprintf("%s $%.2f of %s to reach %.1f%% allocation", action, absFloat(diff), assetType, targetPct),
+				OldValue:    currentValue,
+				NewValue:    targetValue,
+				Difference:  diff,
+			})
+		}
+
+		// Update projected allocation
+		found := false
+		for i := range projected.Allocation {
+			if projected.Allocation[i].Type == assetType {
+				projected.Allocation[i].Value = targetValue
+				projected.Allocation[i].Percent = targetPct
+				found = true
+				break
+			}
+		}
+		if !found && targetValue > 0 {
+			projected.Allocation = append(projected.Allocation, entities.AllocationItem{
+				Type:    assetType,
+				Value:   targetValue,
+				Percent: targetPct,
+			})
+		}
+	}
+
+	// Note: In a rebalance, total value stays the same (we're just moving money around)
+	// But invested amount might change if we realize gains/losses
+
+	return projected, changes, warnings, nil
+}
+
+// absFloat returns the absolute value of a float64
+func absFloat(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// GetTemplates returns the list of predefined scenario templates
+func (e *ScenarioEngine) GetTemplates() []entities.ScenarioTemplate {
+	return entities.GetPredefinedTemplates()
+}

--- a/backend/internal/domain/entities/scenario.go
+++ b/backend/internal/domain/entities/scenario.go
@@ -1,0 +1,214 @@
+package entities
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ScenarioType defines the type of simulation
+type ScenarioType string
+
+const (
+	ScenarioBuyAsset   ScenarioType = "buy_asset"
+	ScenarioSellAsset  ScenarioType = "sell_asset"
+	ScenarioMarketMove ScenarioType = "market_move"
+	ScenarioNewAsset   ScenarioType = "new_asset"
+	ScenarioRebalance  ScenarioType = "rebalance"
+)
+
+// ValidScenarioTypes contains all valid scenario types
+var ValidScenarioTypes = []ScenarioType{
+	ScenarioBuyAsset,
+	ScenarioSellAsset,
+	ScenarioMarketMove,
+	ScenarioNewAsset,
+	ScenarioRebalance,
+}
+
+// IsValid checks if the scenario type is valid
+func (t ScenarioType) IsValid() bool {
+	for _, valid := range ValidScenarioTypes {
+		if t == valid {
+			return true
+		}
+	}
+	return false
+}
+
+// ScenarioRequest is the input for a simulation
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type ScenarioRequest struct {
+	UserID     uuid.UUID      `json:"user_id"`
+	Type       ScenarioType   `json:"type"`
+	Parameters ScenarioParams `json:"parameters"`
+}
+
+// ScenarioParams contains type-specific parameters for simulation
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type ScenarioParams struct {
+	// For buy/sell scenarios
+	AssetID  *uuid.UUID `json:"asset_id,omitempty"`
+	Quantity float64    `json:"quantity,omitempty"`
+	Price    float64    `json:"price,omitempty"`
+
+	// For market move scenarios
+	ChangePercent float64  `json:"change_percent,omitempty"` // e.g., -20 for 20% drop
+	AssetTypes    []string `json:"asset_types,omitempty"`    // Affected asset types (empty = all)
+
+	// For new asset scenarios
+	NewAsset *NewAssetParams `json:"new_asset,omitempty"`
+
+	// For rebalance scenarios
+	TargetAllocation map[string]float64 `json:"target_allocation,omitempty"` // type -> percentage
+}
+
+// NewAssetParams defines parameters for adding a new hypothetical asset
+type NewAssetParams struct {
+	Type          string  `json:"type"`
+	Name          string  `json:"name"`
+	Symbol        string  `json:"symbol,omitempty"`
+	Quantity      float64 `json:"quantity"`
+	PurchasePrice float64 `json:"purchase_price"`
+}
+
+// ScenarioResult is the output of a simulation
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type ScenarioResult struct {
+	CurrentState   PortfolioState `json:"current_state"`
+	ProjectedState PortfolioState `json:"projected_state"`
+	Changes        []ChangeDetail `json:"changes"`
+	AIAnalysis     string         `json:"ai_analysis,omitempty"`
+	Warnings       []string       `json:"warnings,omitempty"`
+}
+
+// PortfolioState represents the state of a portfolio at a point in time
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type PortfolioState struct {
+	TotalValue      float64          `json:"total_value"`
+	TotalInvested   float64          `json:"total_invested"`
+	GainLoss        float64          `json:"gain_loss"`
+	GainLossPercent float64          `json:"gain_loss_percent"`
+	AssetCount      int              `json:"asset_count"`
+	Allocation      []AllocationItem `json:"allocation"`
+}
+
+// AllocationItem represents an allocation by asset type
+type AllocationItem struct {
+	Type    string  `json:"type"`
+	Value   float64 `json:"value"`
+	Percent float64 `json:"percent"`
+}
+
+// ChangeDetail describes a single change in the simulation
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type ChangeDetail struct {
+	Type        string  `json:"type"` // increase, decrease, new, removed
+	Description string  `json:"description"`
+	OldValue    float64 `json:"old_value,omitempty"`
+	NewValue    float64 `json:"new_value,omitempty"`
+	Difference  float64 `json:"difference"`
+}
+
+// Scenario represents a saved simulation in the database
+//
+//nolint:govet // fieldalignment: keep logical field grouping for readability
+type Scenario struct {
+	ID         uuid.UUID       `json:"id"`
+	UserID     uuid.UUID       `json:"user_id"`
+	Type       ScenarioType    `json:"type"`
+	Query      json.RawMessage `json:"query"`
+	Result     json.RawMessage `json:"result"`
+	AIAnalysis *string         `json:"ai_analysis,omitempty"`
+	CreatedAt  time.Time       `json:"created_at"`
+}
+
+// NewScenario creates a new Scenario entity
+func NewScenario(userID uuid.UUID, scenarioType ScenarioType, query, result json.RawMessage, aiAnalysis *string) *Scenario {
+	return &Scenario{
+		ID:         uuid.New(),
+		UserID:     userID,
+		Type:       scenarioType,
+		Query:      query,
+		Result:     result,
+		AIAnalysis: aiAnalysis,
+		CreatedAt:  time.Now().UTC(),
+	}
+}
+
+// ScenarioTemplate represents a predefined scenario template
+type ScenarioTemplate struct {
+	Parameters  ScenarioParams `json:"parameters"`
+	ID          string         `json:"id"`
+	Name        string         `json:"name"`
+	Description string         `json:"description"`
+	Type        ScenarioType   `json:"type"`
+}
+
+// GetPredefinedTemplates returns the list of predefined scenario templates
+func GetPredefinedTemplates() []ScenarioTemplate {
+	return []ScenarioTemplate{
+		{
+			ID:          "market_drop_10",
+			Name:        "10% Market Correction",
+			Description: "Simulates a 10% drop across all assets",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: -10},
+		},
+		{
+			ID:          "market_drop_20",
+			Name:        "20% Market Crash",
+			Description: "Simulates a 20% drop across all assets (bear market)",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: -20},
+		},
+		{
+			ID:          "market_drop_30",
+			Name:        "30% Recession",
+			Description: "Simulates a 30% drop typical of major recessions",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: -30},
+		},
+		{
+			ID:          "market_rally_10",
+			Name:        "10% Bull Rally",
+			Description: "Simulates a 10% increase across all assets",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: 10},
+		},
+		{
+			ID:          "tech_crash",
+			Name:        "Tech Sector Crash",
+			Description: "Simulates a 40% drop in tech stocks only",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: -40, AssetTypes: []string{"stock"}},
+		},
+		{
+			ID:          "crypto_crash",
+			Name:        "Crypto Winter",
+			Description: "Simulates a 50% drop in cryptocurrency assets",
+			Type:        ScenarioMarketMove,
+			Parameters:  ScenarioParams{ChangePercent: -50, AssetTypes: []string{"crypto"}},
+		},
+		{
+			ID:          "balanced_60_40",
+			Name:        "60/40 Portfolio",
+			Description: "Rebalance to classic 60% stocks, 40% bonds allocation",
+			Type:        ScenarioRebalance,
+			Parameters:  ScenarioParams{TargetAllocation: map[string]float64{"stock": 60, "bond": 40}},
+		},
+		{
+			ID:          "conservative",
+			Name:        "Conservative Allocation",
+			Description: "Rebalance to 40% stocks, 40% bonds, 20% cash",
+			Type:        ScenarioRebalance,
+			Parameters:  ScenarioParams{TargetAllocation: map[string]float64{"stock": 40, "bond": 40, "cash": 20}},
+		},
+	}
+}

--- a/backend/internal/domain/repositories/price_history_repository.go
+++ b/backend/internal/domain/repositories/price_history_repository.go
@@ -2,6 +2,7 @@ package repositories
 
 import (
 	"context"
+	"time"
 
 	"github.com/Unikyri/WealthScope/backend/internal/domain/entities"
 )
@@ -9,4 +10,8 @@ import (
 // PriceHistoryRepository defines the interface for persisting historical quotes.
 type PriceHistoryRepository interface {
 	Insert(ctx context.Context, price *entities.PriceHistory) error
+
+	// GetBySymbolAndDateRange retrieves price history for a symbol within a date range.
+	// Used for historical analysis in scenario simulations.
+	GetBySymbolAndDateRange(ctx context.Context, symbol string, from, to time.Time) ([]entities.PriceHistory, error)
 }

--- a/backend/internal/interfaces/http/handlers/scenario.go
+++ b/backend/internal/interfaces/http/handlers/scenario.go
@@ -1,0 +1,189 @@
+package handlers
+
+import (
+	"encoding/json"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/Unikyri/WealthScope/backend/internal/application/services"
+	"github.com/Unikyri/WealthScope/backend/internal/domain/entities"
+	"github.com/Unikyri/WealthScope/backend/internal/interfaces/http/middleware"
+	"github.com/Unikyri/WealthScope/backend/pkg/response"
+)
+
+// ScenarioHandler handles scenario simulation HTTP requests.
+type ScenarioHandler struct {
+	scenarioEngine     *services.ScenarioEngine
+	historicalAnalyzer *services.HistoricalAnalyzer
+}
+
+// NewScenarioHandler creates a new ScenarioHandler.
+func NewScenarioHandler(
+	scenarioEngine *services.ScenarioEngine,
+	historicalAnalyzer *services.HistoricalAnalyzer,
+) *ScenarioHandler {
+	return &ScenarioHandler{
+		scenarioEngine:     scenarioEngine,
+		historicalAnalyzer: historicalAnalyzer,
+	}
+}
+
+// SimulateRequest represents the request body for simulation endpoint.
+//
+//nolint:govet // fieldalignment: keep JSON field order for readability
+type SimulateRequest struct {
+	Type       string          `json:"type" binding:"required"`
+	Parameters json.RawMessage `json:"parameters"`
+}
+
+// SimulateResponse represents the response from the simulate endpoint.
+//
+//nolint:govet // fieldalignment: keep JSON field order for readability
+type SimulateResponse struct {
+	CurrentState   entities.PortfolioState `json:"current_state"`
+	ProjectedState entities.PortfolioState `json:"projected_state"`
+	Changes        []entities.ChangeDetail `json:"changes"`
+	AIAnalysis     string                  `json:"ai_analysis,omitempty"`
+	Warnings       []string                `json:"warnings,omitempty"`
+}
+
+// TemplatesResponse represents the response from the templates endpoint.
+type TemplatesResponse struct {
+	Templates []entities.ScenarioTemplate `json:"templates"`
+}
+
+// HistoricalStatsRequest represents the request for historical stats.
+type HistoricalStatsRequest struct {
+	Symbol string `json:"symbol" binding:"required"`
+	Period string `json:"period"` // 1M, 3M, 6M, 1Y (default: 1Y)
+}
+
+// Simulate handles POST /api/v1/ai/simulate
+// @Summary Run a what-if scenario simulation
+// @Description Simulates investment scenarios like buying/selling assets, market movements, or portfolio rebalancing
+// @Tags Scenarios
+// @Accept json
+// @Produce json
+// @Param request body SimulateRequest true "Simulation parameters"
+// @Success 200 {object} response.Response{data=SimulateResponse}
+// @Failure 400 {object} response.Response
+// @Failure 401 {object} response.Response
+// @Failure 500 {object} response.Response
+// @Security BearerAuth
+// @Router /api/v1/ai/simulate [post]
+func (h *ScenarioHandler) Simulate(c *gin.Context) {
+	// Get user ID from context
+	userIDValue, ok := c.Get(middleware.UserIDKey)
+	if !ok {
+		response.Unauthorized(c, "User not authenticated")
+		return
+	}
+	userIDStr, ok := userIDValue.(string)
+	if !ok {
+		response.BadRequest(c, "Invalid user ID format")
+		return
+	}
+	uid, parseErr := uuid.Parse(userIDStr)
+	if parseErr != nil {
+		response.BadRequest(c, "Invalid user ID")
+		return
+	}
+
+	// Parse request
+	var req SimulateRequest
+	if bindErr := c.ShouldBindJSON(&req); bindErr != nil {
+		response.BadRequest(c, "Invalid request: "+bindErr.Error())
+		return
+	}
+
+	// Parse scenario parameters
+	var params entities.ScenarioParams
+	if len(req.Parameters) > 0 {
+		if unmarshalErr := json.Unmarshal(req.Parameters, &params); unmarshalErr != nil {
+			response.BadRequest(c, "Invalid parameters: "+unmarshalErr.Error())
+			return
+		}
+	}
+
+	// Build scenario request
+	scenarioReq := entities.ScenarioRequest{
+		UserID:     uid,
+		Type:       entities.ScenarioType(req.Type),
+		Parameters: params,
+	}
+
+	// Validate scenario type
+	if !scenarioReq.Type.IsValid() {
+		response.BadRequest(c, "Invalid scenario type: "+req.Type)
+		return
+	}
+
+	// Run simulation
+	result, err := h.scenarioEngine.Simulate(c.Request.Context(), scenarioReq)
+	if err != nil {
+		response.InternalError(c, "Simulation failed: "+err.Error())
+		return
+	}
+
+	// Build response
+	resp := SimulateResponse{
+		CurrentState:   result.CurrentState,
+		ProjectedState: result.ProjectedState,
+		Changes:        result.Changes,
+		AIAnalysis:     result.AIAnalysis,
+		Warnings:       result.Warnings,
+	}
+
+	response.Success(c, resp)
+}
+
+// GetTemplates handles GET /api/v1/ai/scenarios/templates
+// @Summary Get predefined scenario templates
+// @Description Returns a list of predefined scenario templates that users can run
+// @Tags Scenarios
+// @Produce json
+// @Success 200 {object} response.Response{data=TemplatesResponse}
+// @Failure 401 {object} response.Response
+// @Security BearerAuth
+// @Router /api/v1/ai/scenarios/templates [get]
+func (h *ScenarioHandler) GetTemplates(c *gin.Context) {
+	templates := h.scenarioEngine.GetTemplates()
+
+	resp := TemplatesResponse{
+		Templates: templates,
+	}
+
+	response.Success(c, resp)
+}
+
+// GetHistoricalStats handles GET /api/v1/ai/scenarios/historical
+// @Summary Get historical statistics for a symbol
+// @Description Returns historical volatility, drawdown, and other statistics for a symbol
+// @Tags Scenarios
+// @Produce json
+// @Param symbol query string true "Asset symbol (e.g., AAPL)"
+// @Param period query string false "Analysis period (1M, 3M, 6M, 1Y)" default(1Y)
+// @Success 200 {object} response.Response{data=services.HistoricalStats}
+// @Failure 400 {object} response.Response
+// @Failure 401 {object} response.Response
+// @Failure 500 {object} response.Response
+// @Security BearerAuth
+// @Router /api/v1/ai/scenarios/historical [get]
+func (h *ScenarioHandler) GetHistoricalStats(c *gin.Context) {
+	symbol := c.Query("symbol")
+	if symbol == "" {
+		response.BadRequest(c, "symbol is required")
+		return
+	}
+
+	period := c.DefaultQuery("period", "1Y")
+
+	stats, err := h.historicalAnalyzer.GetHistoricalStats(c.Request.Context(), symbol, period)
+	if err != nil {
+		response.InternalError(c, "Failed to get historical stats: "+err.Error())
+		return
+	}
+
+	response.Success(c, stats)
+}


### PR DESCRIPTION
## Summary
Implements the What-If Scenario Simulator backend for financial scenario analysis.

## Changes

### New Files
- `domain/entities/scenario.go` - Domain entities (ScenarioType, Request, Result, 8 templates)
- `application/services/scenario_engine.go` - Core simulation engine with 5 scenario types
- `application/services/historical_analyzer.go` - Historical volatility/drawdown analysis
- `interfaces/http/handlers/scenario.go` - HTTP handler with 3 endpoints

### Modified Files
- `domain/repositories/price_history_repository.go` - Added `GetBySymbolAndDateRange`
- `infrastructure/repositories/postgres_price_history_repository.go` - Implementation
- `interfaces/http/router.go` - Route wiring
- `infrastructure/server/server.go` - Service initialization

## New API Endpoints

| Endpoint | Description |
|----------|-------------|
| `POST /api/v1/ai/simulate` | Run what-if scenario simulation |
| `GET /api/v1/ai/scenarios/templates` | Get 8 predefined templates |
| `GET /api/v1/ai/scenarios/historical` | Get historical stats for symbol |

## Scenario Types
- `buy_asset` - Simulate buying more of an existing asset
- `sell_asset` - Simulate selling an existing asset
- `market_move` - Apply % change to portfolio/sector
- `new_asset` - Add hypothetical new asset
- `rebalance` - Rebalance to target allocation

## Testing
- ✅ `go build ./...` passes
- ✅ `go test ./...` passes (no regressions)

## Related
Closes #243