### PR TITLE
fix(docs): add missing swagger annotations for News API

### DIFF
--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -43,7 +43,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChatRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.ChatRequest"
                         }
                     }
                 ],
@@ -53,13 +53,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ChatResponseDTO"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ChatResponseDTO"
                                         }
                                     }
                                 }
@@ -69,19 +69,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -117,13 +117,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationListResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationListResponse"
                                         }
                                     }
                                 }
@@ -133,13 +133,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -163,7 +163,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateConversationRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.CreateConversationRequest"
                         }
                     }
                 ],
@@ -173,13 +173,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                                         }
                                     }
                                 }
@@ -189,19 +189,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -232,13 +232,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationWithMessagesResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationWithMessagesResponse"
                                         }
                                     }
                                 }
@@ -248,25 +248,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -297,7 +297,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.UpdateConversationRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.UpdateConversationRequest"
                         }
                     }
                 ],
@@ -305,31 +305,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -356,31 +356,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -440,13 +440,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightListResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightListResponse"
                                         }
                                     }
                                 }
@@ -456,13 +456,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -484,13 +484,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                         }
                                     }
                                 }
@@ -500,13 +500,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -528,7 +528,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -536,7 +536,7 @@ const docTemplate = `{
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/handlers.InsightResponse"
+                                                "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                             }
                                         }
                                     }
@@ -547,13 +547,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -575,13 +575,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UnreadCountResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.UnreadCountResponse"
                                         }
                                     }
                                 }
@@ -591,13 +591,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -628,13 +628,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                         }
                                     }
                                 }
@@ -644,25 +644,25 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -691,31 +691,31 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -755,13 +755,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.OCRResponse"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse"
                                         }
                                     }
                                 }
@@ -771,19 +771,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -809,7 +809,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ConfirmOCRAssetsRequest"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest"
                         }
                     }
                 ],
@@ -819,13 +819,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.ConfirmOCRAssetsResponse"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse"
                                         }
                                     }
                                 }
@@ -835,19 +835,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -890,13 +890,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/services.HistoricalStats"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats"
                                         }
                                     }
                                 }
@@ -906,19 +906,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -945,13 +945,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.TemplatesResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.TemplatesResponse"
                                         }
                                     }
                                 }
@@ -961,7 +961,7 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -992,7 +992,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.SimulateRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.SimulateRequest"
                         }
                     }
                 ],
@@ -1002,13 +1002,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SimulateResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SimulateResponse"
                                         }
                                     }
                                 }
@@ -1018,19 +1018,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1052,13 +1052,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.WelcomeResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.WelcomeResponse"
                                         }
                                     }
                                 }
@@ -1068,13 +1068,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1133,13 +1133,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ListAssetsResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ListAssetsResponse"
                                         }
                                     }
                                 }
@@ -1149,13 +1149,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1184,7 +1184,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateAssetRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.CreateAssetRequest"
                         }
                     }
                 ],
@@ -1194,13 +1194,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1210,19 +1210,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1258,13 +1258,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1274,19 +1274,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1322,7 +1322,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.UpdateAssetRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.UpdateAssetRequest"
                         }
                     }
                 ],
@@ -1332,13 +1332,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1348,19 +1348,19 @@ const docTemplate = `{
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1392,25 +1392,25 @@ const docTemplate = `{
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1437,13 +1437,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1453,13 +1453,13 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1489,7 +1489,7 @@ const docTemplate = `{
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.SyncRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncRequest"
                         }
                     }
                 ],
@@ -1499,13 +1499,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SyncResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncResponse"
                                         }
                                     }
                                 }
@@ -1517,13 +1517,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SyncResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncResponse"
                                         }
                                     }
                                 }
@@ -1533,13 +1533,265 @@ const docTemplate = `{
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news": {
+            "get": {
+                "description": "Fetch latest financial news with optional filtering by symbols, keywords, language",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get latest financial news",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated stock symbols (e.g., AAPL,TSLA)",
+                        "name": "symbols",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search keywords",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Language code (default: en)",
+                        "name": "language",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/search": {
+            "get": {
+                "description": "Search for financial news articles by keywords",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Search financial news",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search keywords",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/symbol/{symbol}": {
+            "get": {
+                "description": "Fetch financial news related to a specific stock or crypto symbol",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get news for a specific symbol",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stock symbol (e.g., AAPL)",
+                        "name": "symbol",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/trending": {
+            "get": {
+                "description": "Fetch top trending financial news articles",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get trending financial news",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1561,13 +1813,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PingResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PingResponse"
                                         }
                                     }
                                 }
@@ -1598,13 +1850,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PortfolioRiskResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PortfolioRiskResponse"
                                         }
                                     }
                                 }
@@ -1616,7 +1868,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1634,7 +1886,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1671,13 +1923,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PortfolioSummaryResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PortfolioSummaryResponse"
                                         }
                                     }
                                 }
@@ -1689,7 +1941,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1707,7 +1959,7 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1739,13 +1991,13 @@ const docTemplate = `{
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.HealthResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.HealthResponse"
                                         }
                                     }
                                 }
@@ -1757,33 +2009,7 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "database.HealthStatus": {
-            "type": "object",
-            "properties": {
-                "connected": {
-                    "type": "boolean"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "idle": {
-                    "type": "integer"
-                },
-                "in_use": {
-                    "type": "integer"
-                },
-                "latency": {
-                    "type": "string"
-                },
-                "max_open_connections": {
-                    "type": "integer"
-                },
-                "open_connections": {
-                    "type": "integer"
-                }
-            }
-        },
-        "dto.ConfirmAsset": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset": {
             "type": "object",
             "required": [
                 "currency",
@@ -1820,7 +2046,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ConfirmOCRAssetsRequest": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest": {
             "type": "object",
             "required": [
                 "assets"
@@ -1831,12 +2057,12 @@ const docTemplate = `{
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.ConfirmAsset"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset"
                     }
                 }
             }
         },
-        "dto.ConfirmOCRAssetsResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse": {
             "type": "object",
             "properties": {
                 "asset_ids": {
@@ -1852,7 +2078,7 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.ExtractedAssetResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse": {
             "type": "object",
             "properties": {
                 "confidence": {
@@ -1889,14 +2115,14 @@ const docTemplate = `{
                 }
             }
         },
-        "dto.OCRResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse": {
             "type": "object",
             "properties": {
                 "assets": {
                     "description": "Assets contains all extracted financial assets",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ExtractedAssetResponse"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse"
                     }
                 },
                 "document_type": {
@@ -1912,7 +2138,42 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.AllocationItem": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats": {
+            "type": "object",
+            "properties": {
+                "average_return": {
+                    "type": "number"
+                },
+                "best_day": {
+                    "type": "number"
+                },
+                "data_points": {
+                    "type": "integer"
+                },
+                "max_drawdown": {
+                    "type": "number"
+                },
+                "negative_days": {
+                    "type": "integer"
+                },
+                "period": {
+                    "type": "string"
+                },
+                "positive_days": {
+                    "type": "integer"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "volatility": {
+                    "type": "number"
+                },
+                "worst_day": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem": {
             "type": "object",
             "properties": {
                 "percent": {
@@ -1926,7 +2187,7 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.ChangeDetail": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail": {
             "type": "object",
             "properties": {
                 "description": {
@@ -1947,7 +2208,7 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.NewAssetParams": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams": {
             "type": "object",
             "properties": {
                 "name": {
@@ -1967,13 +2228,13 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.PortfolioState": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState": {
             "type": "object",
             "properties": {
                 "allocation": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.AllocationItem"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem"
                     }
                 },
                 "asset_count": {
@@ -1993,7 +2254,7 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.ScenarioParams": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2015,7 +2276,7 @@ const docTemplate = `{
                     "description": "For new asset scenarios",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/entities.NewAssetParams"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams"
                         }
                     ]
                 },
@@ -2035,7 +2296,7 @@ const docTemplate = `{
                 }
             }
         },
-        "entities.ScenarioTemplate": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2048,14 +2309,14 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "parameters": {
-                    "$ref": "#/definitions/entities.ScenarioParams"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams"
                 },
                 "type": {
-                    "$ref": "#/definitions/entities.ScenarioType"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType"
                 }
             }
         },
-        "entities.ScenarioType": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType": {
             "type": "string",
             "enum": [
                 "buy_asset",
@@ -2072,7 +2333,109 @@ const docTemplate = `{
                 "ScenarioRebalance"
             ]
         },
-        "handlers.AssetResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_url": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "published_at": {
+                    "type": "string"
+                },
+                "sentiment": {
+                    "description": "-1 (negative) to +1 (positive)",
+                    "type": "number"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "symbols": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "idle": {
+                    "type": "integer"
+                },
+                "in_use": {
+                    "type": "integer"
+                },
+                "latency": {
+                    "type": "string"
+                },
+                "max_open_connections": {
+                    "type": "integer"
+                },
+                "open_connections": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.Meta": {
+            "type": "object",
+            "properties": {
+                "request_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.Response": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo"
+                },
+                "meta": {
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Meta"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_interfaces_http_handlers.AssetResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -2129,7 +2492,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.AssetTypeBreakdownResponse": {
+        "internal_interfaces_http_handlers.AssetTypeBreakdownResponse": {
             "type": "object",
             "properties": {
                 "count": {
@@ -2146,7 +2509,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ChatRequest": {
+        "internal_interfaces_http_handlers.ChatRequest": {
             "type": "object",
             "required": [
                 "message"
@@ -2162,27 +2525,27 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ChatResponseDTO": {
+        "internal_interfaces_http_handlers.ChatResponseDTO": {
             "type": "object",
             "properties": {
                 "ai_message": {
-                    "$ref": "#/definitions/handlers.MessageResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                 },
                 "conversation_id": {
                     "type": "string"
                 },
                 "user_message": {
-                    "$ref": "#/definitions/handlers.MessageResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                 }
             }
         },
-        "handlers.ConversationListResponse": {
+        "internal_interfaces_http_handlers.ConversationListResponse": {
             "type": "object",
             "properties": {
                 "conversations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.ConversationResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                     }
                 },
                 "limit": {
@@ -2196,7 +2559,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ConversationResponse": {
+        "internal_interfaces_http_handlers.ConversationResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -2213,21 +2576,21 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ConversationWithMessagesResponse": {
+        "internal_interfaces_http_handlers.ConversationWithMessagesResponse": {
             "type": "object",
             "properties": {
                 "conversation": {
-                    "$ref": "#/definitions/handlers.ConversationResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                 },
                 "messages": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MessageResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                     }
                 }
             }
         },
-        "handlers.CreateAssetRequest": {
+        "internal_interfaces_http_handlers.CreateAssetRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -2285,7 +2648,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.CreateConversationRequest": {
+        "internal_interfaces_http_handlers.CreateConversationRequest": {
             "type": "object",
             "properties": {
                 "title": {
@@ -2294,11 +2657,11 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.HealthResponse": {
+        "internal_interfaces_http_handlers.HealthResponse": {
             "type": "object",
             "properties": {
                 "database": {
-                    "$ref": "#/definitions/database.HealthStatus"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus"
                 },
                 "status": {
                     "type": "string"
@@ -2311,13 +2674,13 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.InsightListResponse": {
+        "internal_interfaces_http_handlers.InsightListResponse": {
             "type": "object",
             "properties": {
                 "insights": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.InsightResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                     }
                 },
                 "limit": {
@@ -2334,7 +2697,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.InsightResponse": {
+        "internal_interfaces_http_handlers.InsightResponse": {
             "type": "object",
             "properties": {
                 "action_items": {
@@ -2375,21 +2738,21 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.ListAssetsResponse": {
+        "internal_interfaces_http_handlers.ListAssetsResponse": {
             "type": "object",
             "properties": {
                 "assets": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.AssetResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/handlers.PaginationInfo"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.PaginationInfo"
                 }
             }
         },
-        "handlers.MessageResponse": {
+        "internal_interfaces_http_handlers.MessageResponse": {
             "type": "object",
             "properties": {
                 "content": {
@@ -2409,7 +2772,27 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.PaginationInfo": {
+        "internal_interfaces_http_handlers.NewsListResponse": {
+            "type": "object",
+            "properties": {
+                "articles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_interfaces_http_handlers.PaginationInfo": {
             "type": "object",
             "properties": {
                 "page": {
@@ -2426,7 +2809,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.PingResponse": {
+        "internal_interfaces_http_handlers.PingResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -2434,13 +2817,13 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.PortfolioRiskResponse": {
+        "internal_interfaces_http_handlers.PortfolioRiskResponse": {
             "type": "object",
             "properties": {
                 "alerts": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.RiskAlertResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.RiskAlertResponse"
                     }
                 },
                 "diversification_level": {
@@ -2453,7 +2836,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.PortfolioSummaryResponse": {
+        "internal_interfaces_http_handlers.PortfolioSummaryResponse": {
             "type": "object",
             "properties": {
                 "asset_count": {
@@ -2462,7 +2845,7 @@ const docTemplate = `{
                 "breakdown_by_type": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.AssetTypeBreakdownResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.AssetTypeBreakdownResponse"
                     }
                 },
                 "gain_loss": {
@@ -2482,7 +2865,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.RiskAlertResponse": {
+        "internal_interfaces_http_handlers.RiskAlertResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -2511,10 +2894,24 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.SimulateRequest": {
-            "type": "object"
+        "internal_interfaces_http_handlers.SimulateRequest": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
         },
-        "handlers.SimulateResponse": {
+        "internal_interfaces_http_handlers.SimulateResponse": {
             "type": "object",
             "properties": {
                 "ai_analysis": {
@@ -2523,14 +2920,14 @@ const docTemplate = `{
                 "changes": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.ChangeDetail"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail"
                     }
                 },
                 "current_state": {
-                    "$ref": "#/definitions/entities.PortfolioState"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState"
                 },
                 "projected_state": {
-                    "$ref": "#/definitions/entities.PortfolioState"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState"
                 },
                 "warnings": {
                     "type": "array",
@@ -2540,7 +2937,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.SyncRequest": {
+        "internal_interfaces_http_handlers.SyncRequest": {
             "type": "object",
             "properties": {
                 "display_name": {
@@ -2548,29 +2945,29 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.SyncResponse": {
+        "internal_interfaces_http_handlers.SyncResponse": {
             "type": "object",
             "properties": {
                 "created": {
                     "type": "boolean"
                 },
                 "user": {
-                    "$ref": "#/definitions/handlers.UserResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.UserResponse"
                 }
             }
         },
-        "handlers.TemplatesResponse": {
+        "internal_interfaces_http_handlers.TemplatesResponse": {
             "type": "object",
             "properties": {
                 "templates": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.ScenarioTemplate"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate"
                     }
                 }
             }
         },
-        "handlers.UnreadCountResponse": {
+        "internal_interfaces_http_handlers.UnreadCountResponse": {
             "type": "object",
             "properties": {
                 "count": {
@@ -2578,7 +2975,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.UpdateAssetRequest": {
+        "internal_interfaces_http_handlers.UpdateAssetRequest": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -2630,7 +3027,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.UpdateConversationRequest": {
+        "internal_interfaces_http_handlers.UpdateConversationRequest": {
             "type": "object",
             "required": [
                 "title"
@@ -2643,7 +3040,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.UserResponse": {
+        "internal_interfaces_http_handlers.UserResponse": {
             "type": "object",
             "properties": {
                 "avatar_url": {
@@ -2666,7 +3063,7 @@ const docTemplate = `{
                 }
             }
         },
-        "handlers.WelcomeResponse": {
+        "internal_interfaces_http_handlers.WelcomeResponse": {
             "type": "object",
             "properties": {
                 "conversation_starters": {
@@ -2677,75 +3074,6 @@ const docTemplate = `{
                 },
                 "message": {
                     "type": "string"
-                }
-            }
-        },
-        "response.ErrorInfo": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "response.Meta": {
-            "type": "object",
-            "properties": {
-                "request_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "response.Response": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "error": {
-                    "$ref": "#/definitions/response.ErrorInfo"
-                },
-                "meta": {
-                    "$ref": "#/definitions/response.Meta"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "services.HistoricalStats": {
-            "type": "object",
-            "properties": {
-                "average_return": {
-                    "type": "number"
-                },
-                "best_day": {
-                    "type": "number"
-                },
-                "data_points": {
-                    "type": "integer"
-                },
-                "max_drawdown": {
-                    "type": "number"
-                },
-                "negative_days": {
-                    "type": "integer"
-                },
-                "period": {
-                    "type": "string"
-                },
-                "positive_days": {
-                    "type": "integer"
-                },
-                "symbol": {
-                    "type": "string"
-                },
-                "volatility": {
-                    "type": "number"
-                },
-                "worst_day": {
-                    "type": "number"
                 }
             }
         }

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -41,7 +41,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.ChatRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.ChatRequest"
                         }
                     }
                 ],
@@ -51,13 +51,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ChatResponseDTO"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ChatResponseDTO"
                                         }
                                     }
                                 }
@@ -67,19 +67,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -115,13 +115,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationListResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationListResponse"
                                         }
                                     }
                                 }
@@ -131,13 +131,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -161,7 +161,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateConversationRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.CreateConversationRequest"
                         }
                     }
                 ],
@@ -171,13 +171,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                                         }
                                     }
                                 }
@@ -187,19 +187,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -230,13 +230,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ConversationWithMessagesResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationWithMessagesResponse"
                                         }
                                     }
                                 }
@@ -246,25 +246,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -295,7 +295,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.UpdateConversationRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.UpdateConversationRequest"
                         }
                     }
                 ],
@@ -303,31 +303,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -354,31 +354,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -438,13 +438,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightListResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightListResponse"
                                         }
                                     }
                                 }
@@ -454,13 +454,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -482,13 +482,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                         }
                                     }
                                 }
@@ -498,13 +498,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -526,7 +526,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -534,7 +534,7 @@
                                         "data": {
                                             "type": "array",
                                             "items": {
-                                                "$ref": "#/definitions/handlers.InsightResponse"
+                                                "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                             }
                                         }
                                     }
@@ -545,13 +545,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -573,13 +573,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UnreadCountResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.UnreadCountResponse"
                                         }
                                     }
                                 }
@@ -589,13 +589,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -626,13 +626,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.InsightResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                                         }
                                     }
                                 }
@@ -642,25 +642,25 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -689,31 +689,31 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -753,13 +753,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.OCRResponse"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse"
                                         }
                                     }
                                 }
@@ -769,19 +769,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -807,7 +807,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/dto.ConfirmOCRAssetsRequest"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest"
                         }
                     }
                 ],
@@ -817,13 +817,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/dto.ConfirmOCRAssetsResponse"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse"
                                         }
                                     }
                                 }
@@ -833,19 +833,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -888,13 +888,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/services.HistoricalStats"
+                                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats"
                                         }
                                     }
                                 }
@@ -904,19 +904,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -943,13 +943,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.TemplatesResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.TemplatesResponse"
                                         }
                                     }
                                 }
@@ -959,7 +959,7 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -990,7 +990,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.SimulateRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.SimulateRequest"
                         }
                     }
                 ],
@@ -1000,13 +1000,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SimulateResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SimulateResponse"
                                         }
                                     }
                                 }
@@ -1016,19 +1016,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1050,13 +1050,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.WelcomeResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.WelcomeResponse"
                                         }
                                     }
                                 }
@@ -1066,13 +1066,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1131,13 +1131,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.ListAssetsResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.ListAssetsResponse"
                                         }
                                     }
                                 }
@@ -1147,13 +1147,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1182,7 +1182,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.CreateAssetRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.CreateAssetRequest"
                         }
                     }
                 ],
@@ -1192,13 +1192,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1208,19 +1208,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1256,13 +1256,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1272,19 +1272,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1320,7 +1320,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/handlers.UpdateAssetRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.UpdateAssetRequest"
                         }
                     }
                 ],
@@ -1330,13 +1330,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.AssetResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                                         }
                                     }
                                 }
@@ -1346,19 +1346,19 @@
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1390,25 +1390,25 @@
                     "200": {
                         "description": "OK",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "400": {
                         "description": "Bad Request",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1435,13 +1435,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.UserResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.UserResponse"
                                         }
                                     }
                                 }
@@ -1451,13 +1451,13 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "404": {
                         "description": "Not Found",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1487,7 +1487,7 @@
                         "name": "request",
                         "in": "body",
                         "schema": {
-                            "$ref": "#/definitions/handlers.SyncRequest"
+                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncRequest"
                         }
                     }
                 ],
@@ -1497,13 +1497,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SyncResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncResponse"
                                         }
                                     }
                                 }
@@ -1515,13 +1515,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.SyncResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.SyncResponse"
                                         }
                                     }
                                 }
@@ -1531,13 +1531,265 @@
                     "401": {
                         "description": "Unauthorized",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {
-                            "$ref": "#/definitions/response.Response"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news": {
+            "get": {
+                "description": "Fetch latest financial news with optional filtering by symbols, keywords, language",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get latest financial news",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Comma-separated stock symbols (e.g., AAPL,TSLA)",
+                        "name": "symbols",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Search keywords",
+                        "name": "q",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Language code (default: en)",
+                        "name": "language",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Page number (default 1)",
+                        "name": "page",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/search": {
+            "get": {
+                "description": "Search for financial news articles by keywords",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Search financial news",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Search keywords",
+                        "name": "q",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/symbol/{symbol}": {
+            "get": {
+                "description": "Fetch financial news related to a specific stock or crypto symbol",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get news for a specific symbol",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Stock symbol (e.g., AAPL)",
+                        "name": "symbol",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/news/trending": {
+            "get": {
+                "description": "Fetch top trending financial news articles",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "News"
+                ],
+                "summary": "Get trending financial news",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Max articles (default 10, max 50)",
+                        "name": "limit",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "allOf": [
+                                {
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
+                                },
+                                {
+                                    "type": "object",
+                                    "properties": {
+                                        "data": {
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.NewsListResponse"
+                                        }
+                                    }
+                                }
+                            ]
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                         }
                     }
                 }
@@ -1559,13 +1811,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PingResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PingResponse"
                                         }
                                     }
                                 }
@@ -1596,13 +1848,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PortfolioRiskResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PortfolioRiskResponse"
                                         }
                                     }
                                 }
@@ -1614,7 +1866,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1632,7 +1884,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1669,13 +1921,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.PortfolioSummaryResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.PortfolioSummaryResponse"
                                         }
                                     }
                                 }
@@ -1687,7 +1939,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1705,7 +1957,7 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
@@ -1737,13 +1989,13 @@
                         "schema": {
                             "allOf": [
                                 {
-                                    "$ref": "#/definitions/response.Response"
+                                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response"
                                 },
                                 {
                                     "type": "object",
                                     "properties": {
                                         "data": {
-                                            "$ref": "#/definitions/handlers.HealthResponse"
+                                            "$ref": "#/definitions/internal_interfaces_http_handlers.HealthResponse"
                                         }
                                     }
                                 }
@@ -1755,33 +2007,7 @@
         }
     },
     "definitions": {
-        "database.HealthStatus": {
-            "type": "object",
-            "properties": {
-                "connected": {
-                    "type": "boolean"
-                },
-                "error": {
-                    "type": "string"
-                },
-                "idle": {
-                    "type": "integer"
-                },
-                "in_use": {
-                    "type": "integer"
-                },
-                "latency": {
-                    "type": "string"
-                },
-                "max_open_connections": {
-                    "type": "integer"
-                },
-                "open_connections": {
-                    "type": "integer"
-                }
-            }
-        },
-        "dto.ConfirmAsset": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset": {
             "type": "object",
             "required": [
                 "currency",
@@ -1818,7 +2044,7 @@
                 }
             }
         },
-        "dto.ConfirmOCRAssetsRequest": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest": {
             "type": "object",
             "required": [
                 "assets"
@@ -1829,12 +2055,12 @@
                     "type": "array",
                     "minItems": 1,
                     "items": {
-                        "$ref": "#/definitions/dto.ConfirmAsset"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset"
                     }
                 }
             }
         },
-        "dto.ConfirmOCRAssetsResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse": {
             "type": "object",
             "properties": {
                 "asset_ids": {
@@ -1850,7 +2076,7 @@
                 }
             }
         },
-        "dto.ExtractedAssetResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse": {
             "type": "object",
             "properties": {
                 "confidence": {
@@ -1887,14 +2113,14 @@
                 }
             }
         },
-        "dto.OCRResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse": {
             "type": "object",
             "properties": {
                 "assets": {
                     "description": "Assets contains all extracted financial assets",
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/dto.ExtractedAssetResponse"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse"
                     }
                 },
                 "document_type": {
@@ -1910,7 +2136,42 @@
                 }
             }
         },
-        "entities.AllocationItem": {
+        "github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats": {
+            "type": "object",
+            "properties": {
+                "average_return": {
+                    "type": "number"
+                },
+                "best_day": {
+                    "type": "number"
+                },
+                "data_points": {
+                    "type": "integer"
+                },
+                "max_drawdown": {
+                    "type": "number"
+                },
+                "negative_days": {
+                    "type": "integer"
+                },
+                "period": {
+                    "type": "string"
+                },
+                "positive_days": {
+                    "type": "integer"
+                },
+                "symbol": {
+                    "type": "string"
+                },
+                "volatility": {
+                    "type": "number"
+                },
+                "worst_day": {
+                    "type": "number"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem": {
             "type": "object",
             "properties": {
                 "percent": {
@@ -1924,7 +2185,7 @@
                 }
             }
         },
-        "entities.ChangeDetail": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail": {
             "type": "object",
             "properties": {
                 "description": {
@@ -1945,7 +2206,7 @@
                 }
             }
         },
-        "entities.NewAssetParams": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams": {
             "type": "object",
             "properties": {
                 "name": {
@@ -1965,13 +2226,13 @@
                 }
             }
         },
-        "entities.PortfolioState": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState": {
             "type": "object",
             "properties": {
                 "allocation": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.AllocationItem"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem"
                     }
                 },
                 "asset_count": {
@@ -1991,7 +2252,7 @@
                 }
             }
         },
-        "entities.ScenarioParams": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams": {
             "type": "object",
             "properties": {
                 "asset_id": {
@@ -2013,7 +2274,7 @@
                     "description": "For new asset scenarios",
                     "allOf": [
                         {
-                            "$ref": "#/definitions/entities.NewAssetParams"
+                            "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams"
                         }
                     ]
                 },
@@ -2033,7 +2294,7 @@
                 }
             }
         },
-        "entities.ScenarioTemplate": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate": {
             "type": "object",
             "properties": {
                 "description": {
@@ -2046,14 +2307,14 @@
                     "type": "string"
                 },
                 "parameters": {
-                    "$ref": "#/definitions/entities.ScenarioParams"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams"
                 },
                 "type": {
-                    "$ref": "#/definitions/entities.ScenarioType"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType"
                 }
             }
         },
-        "entities.ScenarioType": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType": {
             "type": "string",
             "enum": [
                 "buy_asset",
@@ -2070,7 +2331,109 @@
                 "ScenarioRebalance"
             ]
         },
-        "handlers.AssetResponse": {
+        "github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle": {
+            "type": "object",
+            "properties": {
+                "content": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "image_url": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "published_at": {
+                    "type": "string"
+                },
+                "sentiment": {
+                    "description": "-1 (negative) to +1 (positive)",
+                    "type": "number"
+                },
+                "source": {
+                    "type": "string"
+                },
+                "symbols": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "title": {
+                    "type": "string"
+                },
+                "url": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus": {
+            "type": "object",
+            "properties": {
+                "connected": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "idle": {
+                    "type": "integer"
+                },
+                "in_use": {
+                    "type": "integer"
+                },
+                "latency": {
+                    "type": "string"
+                },
+                "max_open_connections": {
+                    "type": "integer"
+                },
+                "open_connections": {
+                    "type": "integer"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.Meta": {
+            "type": "object",
+            "properties": {
+                "request_id": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_Unikyri_WealthScope_backend_pkg_response.Response": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo"
+                },
+                "meta": {
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Meta"
+                },
+                "success": {
+                    "type": "boolean"
+                }
+            }
+        },
+        "internal_interfaces_http_handlers.AssetResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -2127,7 +2490,7 @@
                 }
             }
         },
-        "handlers.AssetTypeBreakdownResponse": {
+        "internal_interfaces_http_handlers.AssetTypeBreakdownResponse": {
             "type": "object",
             "properties": {
                 "count": {
@@ -2144,7 +2507,7 @@
                 }
             }
         },
-        "handlers.ChatRequest": {
+        "internal_interfaces_http_handlers.ChatRequest": {
             "type": "object",
             "required": [
                 "message"
@@ -2160,27 +2523,27 @@
                 }
             }
         },
-        "handlers.ChatResponseDTO": {
+        "internal_interfaces_http_handlers.ChatResponseDTO": {
             "type": "object",
             "properties": {
                 "ai_message": {
-                    "$ref": "#/definitions/handlers.MessageResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                 },
                 "conversation_id": {
                     "type": "string"
                 },
                 "user_message": {
-                    "$ref": "#/definitions/handlers.MessageResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                 }
             }
         },
-        "handlers.ConversationListResponse": {
+        "internal_interfaces_http_handlers.ConversationListResponse": {
             "type": "object",
             "properties": {
                 "conversations": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.ConversationResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                     }
                 },
                 "limit": {
@@ -2194,7 +2557,7 @@
                 }
             }
         },
-        "handlers.ConversationResponse": {
+        "internal_interfaces_http_handlers.ConversationResponse": {
             "type": "object",
             "properties": {
                 "created_at": {
@@ -2211,21 +2574,21 @@
                 }
             }
         },
-        "handlers.ConversationWithMessagesResponse": {
+        "internal_interfaces_http_handlers.ConversationWithMessagesResponse": {
             "type": "object",
             "properties": {
                 "conversation": {
-                    "$ref": "#/definitions/handlers.ConversationResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.ConversationResponse"
                 },
                 "messages": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.MessageResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.MessageResponse"
                     }
                 }
             }
         },
-        "handlers.CreateAssetRequest": {
+        "internal_interfaces_http_handlers.CreateAssetRequest": {
             "type": "object",
             "required": [
                 "name",
@@ -2283,7 +2646,7 @@
                 }
             }
         },
-        "handlers.CreateConversationRequest": {
+        "internal_interfaces_http_handlers.CreateConversationRequest": {
             "type": "object",
             "properties": {
                 "title": {
@@ -2292,11 +2655,11 @@
                 }
             }
         },
-        "handlers.HealthResponse": {
+        "internal_interfaces_http_handlers.HealthResponse": {
             "type": "object",
             "properties": {
                 "database": {
-                    "$ref": "#/definitions/database.HealthStatus"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus"
                 },
                 "status": {
                     "type": "string"
@@ -2309,13 +2672,13 @@
                 }
             }
         },
-        "handlers.InsightListResponse": {
+        "internal_interfaces_http_handlers.InsightListResponse": {
             "type": "object",
             "properties": {
                 "insights": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.InsightResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.InsightResponse"
                     }
                 },
                 "limit": {
@@ -2332,7 +2695,7 @@
                 }
             }
         },
-        "handlers.InsightResponse": {
+        "internal_interfaces_http_handlers.InsightResponse": {
             "type": "object",
             "properties": {
                 "action_items": {
@@ -2373,21 +2736,21 @@
                 }
             }
         },
-        "handlers.ListAssetsResponse": {
+        "internal_interfaces_http_handlers.ListAssetsResponse": {
             "type": "object",
             "properties": {
                 "assets": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.AssetResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.AssetResponse"
                     }
                 },
                 "pagination": {
-                    "$ref": "#/definitions/handlers.PaginationInfo"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.PaginationInfo"
                 }
             }
         },
-        "handlers.MessageResponse": {
+        "internal_interfaces_http_handlers.MessageResponse": {
             "type": "object",
             "properties": {
                 "content": {
@@ -2407,7 +2770,27 @@
                 }
             }
         },
-        "handlers.PaginationInfo": {
+        "internal_interfaces_http_handlers.NewsListResponse": {
+            "type": "object",
+            "properties": {
+                "articles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle"
+                    }
+                },
+                "limit": {
+                    "type": "integer"
+                },
+                "page": {
+                    "type": "integer"
+                },
+                "total": {
+                    "type": "integer"
+                }
+            }
+        },
+        "internal_interfaces_http_handlers.PaginationInfo": {
             "type": "object",
             "properties": {
                 "page": {
@@ -2424,7 +2807,7 @@
                 }
             }
         },
-        "handlers.PingResponse": {
+        "internal_interfaces_http_handlers.PingResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -2432,13 +2815,13 @@
                 }
             }
         },
-        "handlers.PortfolioRiskResponse": {
+        "internal_interfaces_http_handlers.PortfolioRiskResponse": {
             "type": "object",
             "properties": {
                 "alerts": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.RiskAlertResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.RiskAlertResponse"
                     }
                 },
                 "diversification_level": {
@@ -2451,7 +2834,7 @@
                 }
             }
         },
-        "handlers.PortfolioSummaryResponse": {
+        "internal_interfaces_http_handlers.PortfolioSummaryResponse": {
             "type": "object",
             "properties": {
                 "asset_count": {
@@ -2460,7 +2843,7 @@
                 "breakdown_by_type": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/handlers.AssetTypeBreakdownResponse"
+                        "$ref": "#/definitions/internal_interfaces_http_handlers.AssetTypeBreakdownResponse"
                     }
                 },
                 "gain_loss": {
@@ -2480,7 +2863,7 @@
                 }
             }
         },
-        "handlers.RiskAlertResponse": {
+        "internal_interfaces_http_handlers.RiskAlertResponse": {
             "type": "object",
             "properties": {
                 "message": {
@@ -2509,10 +2892,24 @@
                 }
             }
         },
-        "handlers.SimulateRequest": {
-            "type": "object"
+        "internal_interfaces_http_handlers.SimulateRequest": {
+            "type": "object",
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "parameters": {
+                    "type": "array",
+                    "items": {
+                        "type": "integer"
+                    }
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
         },
-        "handlers.SimulateResponse": {
+        "internal_interfaces_http_handlers.SimulateResponse": {
             "type": "object",
             "properties": {
                 "ai_analysis": {
@@ -2521,14 +2918,14 @@
                 "changes": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.ChangeDetail"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail"
                     }
                 },
                 "current_state": {
-                    "$ref": "#/definitions/entities.PortfolioState"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState"
                 },
                 "projected_state": {
-                    "$ref": "#/definitions/entities.PortfolioState"
+                    "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState"
                 },
                 "warnings": {
                     "type": "array",
@@ -2538,7 +2935,7 @@
                 }
             }
         },
-        "handlers.SyncRequest": {
+        "internal_interfaces_http_handlers.SyncRequest": {
             "type": "object",
             "properties": {
                 "display_name": {
@@ -2546,29 +2943,29 @@
                 }
             }
         },
-        "handlers.SyncResponse": {
+        "internal_interfaces_http_handlers.SyncResponse": {
             "type": "object",
             "properties": {
                 "created": {
                     "type": "boolean"
                 },
                 "user": {
-                    "$ref": "#/definitions/handlers.UserResponse"
+                    "$ref": "#/definitions/internal_interfaces_http_handlers.UserResponse"
                 }
             }
         },
-        "handlers.TemplatesResponse": {
+        "internal_interfaces_http_handlers.TemplatesResponse": {
             "type": "object",
             "properties": {
                 "templates": {
                     "type": "array",
                     "items": {
-                        "$ref": "#/definitions/entities.ScenarioTemplate"
+                        "$ref": "#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate"
                     }
                 }
             }
         },
-        "handlers.UnreadCountResponse": {
+        "internal_interfaces_http_handlers.UnreadCountResponse": {
             "type": "object",
             "properties": {
                 "count": {
@@ -2576,7 +2973,7 @@
                 }
             }
         },
-        "handlers.UpdateAssetRequest": {
+        "internal_interfaces_http_handlers.UpdateAssetRequest": {
             "type": "object",
             "properties": {
                 "currency": {
@@ -2628,7 +3025,7 @@
                 }
             }
         },
-        "handlers.UpdateConversationRequest": {
+        "internal_interfaces_http_handlers.UpdateConversationRequest": {
             "type": "object",
             "required": [
                 "title"
@@ -2641,7 +3038,7 @@
                 }
             }
         },
-        "handlers.UserResponse": {
+        "internal_interfaces_http_handlers.UserResponse": {
             "type": "object",
             "properties": {
                 "avatar_url": {
@@ -2664,7 +3061,7 @@
                 }
             }
         },
-        "handlers.WelcomeResponse": {
+        "internal_interfaces_http_handlers.WelcomeResponse": {
             "type": "object",
             "properties": {
                 "conversation_starters": {
@@ -2675,75 +3072,6 @@
                 },
                 "message": {
                     "type": "string"
-                }
-            }
-        },
-        "response.ErrorInfo": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "string"
-                },
-                "message": {
-                    "type": "string"
-                }
-            }
-        },
-        "response.Meta": {
-            "type": "object",
-            "properties": {
-                "request_id": {
-                    "type": "string"
-                }
-            }
-        },
-        "response.Response": {
-            "type": "object",
-            "properties": {
-                "data": {},
-                "error": {
-                    "$ref": "#/definitions/response.ErrorInfo"
-                },
-                "meta": {
-                    "$ref": "#/definitions/response.Meta"
-                },
-                "success": {
-                    "type": "boolean"
-                }
-            }
-        },
-        "services.HistoricalStats": {
-            "type": "object",
-            "properties": {
-                "average_return": {
-                    "type": "number"
-                },
-                "best_day": {
-                    "type": "number"
-                },
-                "data_points": {
-                    "type": "integer"
-                },
-                "max_drawdown": {
-                    "type": "number"
-                },
-                "negative_days": {
-                    "type": "integer"
-                },
-                "period": {
-                    "type": "string"
-                },
-                "positive_days": {
-                    "type": "integer"
-                },
-                "symbol": {
-                    "type": "string"
-                },
-                "volatility": {
-                    "type": "number"
-                },
-                "worst_day": {
-                    "type": "number"
                 }
             }
         }

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -1,23 +1,6 @@
 basePath: /
 definitions:
-  database.HealthStatus:
-    properties:
-      connected:
-        type: boolean
-      error:
-        type: string
-      idle:
-        type: integer
-      in_use:
-        type: integer
-      latency:
-        type: string
-      max_open_connections:
-        type: integer
-      open_connections:
-        type: integer
-    type: object
-  dto.ConfirmAsset:
+  github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset:
     properties:
       currency:
         description: Currency is the currency code (required)
@@ -45,18 +28,18 @@ definitions:
     - quantity
     - type
     type: object
-  dto.ConfirmOCRAssetsRequest:
+  github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest:
     properties:
       assets:
         description: Assets contains the list of assets to confirm/create
         items:
-          $ref: '#/definitions/dto.ConfirmAsset'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmAsset'
         minItems: 1
         type: array
     required:
     - assets
     type: object
-  dto.ConfirmOCRAssetsResponse:
+  github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse:
     properties:
       asset_ids:
         description: AssetIDs contains the IDs of the created assets
@@ -67,7 +50,7 @@ definitions:
         description: CreatedCount is the number of assets successfully created
         type: integer
     type: object
-  dto.ExtractedAssetResponse:
+  github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse:
     properties:
       confidence:
         description: Confidence is the OCR confidence score (0.0 to 1.0)
@@ -94,12 +77,12 @@ definitions:
         description: Type is the asset category
         type: string
     type: object
-  dto.OCRResponse:
+  github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse:
     properties:
       assets:
         description: Assets contains all extracted financial assets
         items:
-          $ref: '#/definitions/dto.ExtractedAssetResponse'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ExtractedAssetResponse'
         type: array
       document_type:
         description: DocumentType identifies the type of document processed
@@ -110,7 +93,30 @@ definitions:
           type: string
         type: array
     type: object
-  entities.AllocationItem:
+  github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats:
+    properties:
+      average_return:
+        type: number
+      best_day:
+        type: number
+      data_points:
+        type: integer
+      max_drawdown:
+        type: number
+      negative_days:
+        type: integer
+      period:
+        type: string
+      positive_days:
+        type: integer
+      symbol:
+        type: string
+      volatility:
+        type: number
+      worst_day:
+        type: number
+    type: object
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem:
     properties:
       percent:
         type: number
@@ -119,7 +125,7 @@ definitions:
       value:
         type: number
     type: object
-  entities.ChangeDetail:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail:
     properties:
       description:
         type: string
@@ -133,7 +139,7 @@ definitions:
         description: increase, decrease, new, removed
         type: string
     type: object
-  entities.NewAssetParams:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams:
     properties:
       name:
         type: string
@@ -146,11 +152,11 @@ definitions:
       type:
         type: string
     type: object
-  entities.PortfolioState:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState:
     properties:
       allocation:
         items:
-          $ref: '#/definitions/entities.AllocationItem'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.AllocationItem'
         type: array
       asset_count:
         type: integer
@@ -163,7 +169,7 @@ definitions:
       total_value:
         type: number
     type: object
-  entities.ScenarioParams:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams:
     properties:
       asset_id:
         description: For buy/sell scenarios
@@ -178,7 +184,7 @@ definitions:
         type: number
       new_asset:
         allOf:
-        - $ref: '#/definitions/entities.NewAssetParams'
+        - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.NewAssetParams'
         description: For new asset scenarios
       price:
         type: number
@@ -191,7 +197,7 @@ definitions:
         description: For rebalance scenarios
         type: object
     type: object
-  entities.ScenarioTemplate:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate:
     properties:
       description:
         type: string
@@ -200,11 +206,11 @@ definitions:
       name:
         type: string
       parameters:
-        $ref: '#/definitions/entities.ScenarioParams'
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioParams'
       type:
-        $ref: '#/definitions/entities.ScenarioType'
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType'
     type: object
-  entities.ScenarioType:
+  github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioType:
     enum:
     - buy_asset
     - sell_asset
@@ -218,7 +224,74 @@ definitions:
     - ScenarioMarketMove
     - ScenarioNewAsset
     - ScenarioRebalance
-  handlers.AssetResponse:
+  github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle:
+    properties:
+      content:
+        type: string
+      description:
+        type: string
+      id:
+        type: string
+      image_url:
+        type: string
+      provider:
+        type: string
+      published_at:
+        type: string
+      sentiment:
+        description: -1 (negative) to +1 (positive)
+        type: number
+      source:
+        type: string
+      symbols:
+        items:
+          type: string
+        type: array
+      title:
+        type: string
+      url:
+        type: string
+    type: object
+  github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus:
+    properties:
+      connected:
+        type: boolean
+      error:
+        type: string
+      idle:
+        type: integer
+      in_use:
+        type: integer
+      latency:
+        type: string
+      max_open_connections:
+        type: integer
+      open_connections:
+        type: integer
+    type: object
+  github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo:
+    properties:
+      code:
+        type: string
+      message:
+        type: string
+    type: object
+  github_com_Unikyri_WealthScope_backend_pkg_response.Meta:
+    properties:
+      request_id:
+        type: string
+    type: object
+  github_com_Unikyri_WealthScope_backend_pkg_response.Response:
+    properties:
+      data: {}
+      error:
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.ErrorInfo'
+      meta:
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Meta'
+      success:
+        type: boolean
+    type: object
+  internal_interfaces_http_handlers.AssetResponse:
     properties:
       created_at:
         type: string
@@ -256,7 +329,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  handlers.AssetTypeBreakdownResponse:
+  internal_interfaces_http_handlers.AssetTypeBreakdownResponse:
     properties:
       count:
         type: integer
@@ -267,7 +340,7 @@ definitions:
       value:
         type: number
     type: object
-  handlers.ChatRequest:
+  internal_interfaces_http_handlers.ChatRequest:
     properties:
       conversation_id:
         type: string
@@ -278,20 +351,20 @@ definitions:
     required:
     - message
     type: object
-  handlers.ChatResponseDTO:
+  internal_interfaces_http_handlers.ChatResponseDTO:
     properties:
       ai_message:
-        $ref: '#/definitions/handlers.MessageResponse'
+        $ref: '#/definitions/internal_interfaces_http_handlers.MessageResponse'
       conversation_id:
         type: string
       user_message:
-        $ref: '#/definitions/handlers.MessageResponse'
+        $ref: '#/definitions/internal_interfaces_http_handlers.MessageResponse'
     type: object
-  handlers.ConversationListResponse:
+  internal_interfaces_http_handlers.ConversationListResponse:
     properties:
       conversations:
         items:
-          $ref: '#/definitions/handlers.ConversationResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.ConversationResponse'
         type: array
       limit:
         type: integer
@@ -300,7 +373,7 @@ definitions:
       total:
         type: integer
     type: object
-  handlers.ConversationResponse:
+  internal_interfaces_http_handlers.ConversationResponse:
     properties:
       created_at:
         type: string
@@ -311,16 +384,16 @@ definitions:
       updated_at:
         type: string
     type: object
-  handlers.ConversationWithMessagesResponse:
+  internal_interfaces_http_handlers.ConversationWithMessagesResponse:
     properties:
       conversation:
-        $ref: '#/definitions/handlers.ConversationResponse'
+        $ref: '#/definitions/internal_interfaces_http_handlers.ConversationResponse'
       messages:
         items:
-          $ref: '#/definitions/handlers.MessageResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.MessageResponse'
         type: array
     type: object
-  handlers.CreateAssetRequest:
+  internal_interfaces_http_handlers.CreateAssetRequest:
     properties:
       currency:
         type: string
@@ -364,16 +437,16 @@ definitions:
     - quantity
     - type
     type: object
-  handlers.CreateConversationRequest:
+  internal_interfaces_http_handlers.CreateConversationRequest:
     properties:
       title:
         maxLength: 255
         type: string
     type: object
-  handlers.HealthResponse:
+  internal_interfaces_http_handlers.HealthResponse:
     properties:
       database:
-        $ref: '#/definitions/database.HealthStatus'
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_infrastructure_database.HealthStatus'
       status:
         type: string
       timestamp:
@@ -381,11 +454,11 @@ definitions:
       version:
         type: string
     type: object
-  handlers.InsightListResponse:
+  internal_interfaces_http_handlers.InsightListResponse:
     properties:
       insights:
         items:
-          $ref: '#/definitions/handlers.InsightResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.InsightResponse'
         type: array
       limit:
         type: integer
@@ -396,7 +469,7 @@ definitions:
       unread_count:
         type: integer
     type: object
-  handlers.InsightResponse:
+  internal_interfaces_http_handlers.InsightResponse:
     properties:
       action_items:
         items:
@@ -423,16 +496,16 @@ definitions:
       type:
         type: string
     type: object
-  handlers.ListAssetsResponse:
+  internal_interfaces_http_handlers.ListAssetsResponse:
     properties:
       assets:
         items:
-          $ref: '#/definitions/handlers.AssetResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.AssetResponse'
         type: array
       pagination:
-        $ref: '#/definitions/handlers.PaginationInfo'
+        $ref: '#/definitions/internal_interfaces_http_handlers.PaginationInfo'
     type: object
-  handlers.MessageResponse:
+  internal_interfaces_http_handlers.MessageResponse:
     properties:
       content:
         type: string
@@ -445,7 +518,20 @@ definitions:
       role:
         type: string
     type: object
-  handlers.PaginationInfo:
+  internal_interfaces_http_handlers.NewsListResponse:
+    properties:
+      articles:
+        items:
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_services.NewsArticle'
+        type: array
+      limit:
+        type: integer
+      page:
+        type: integer
+      total:
+        type: integer
+    type: object
+  internal_interfaces_http_handlers.PaginationInfo:
     properties:
       page:
         type: integer
@@ -456,16 +542,16 @@ definitions:
       total_pages:
         type: integer
     type: object
-  handlers.PingResponse:
+  internal_interfaces_http_handlers.PingResponse:
     properties:
       message:
         type: string
     type: object
-  handlers.PortfolioRiskResponse:
+  internal_interfaces_http_handlers.PortfolioRiskResponse:
     properties:
       alerts:
         items:
-          $ref: '#/definitions/handlers.RiskAlertResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.RiskAlertResponse'
         type: array
       diversification_level:
         example: moderate
@@ -474,13 +560,13 @@ definitions:
         example: 35
         type: integer
     type: object
-  handlers.PortfolioSummaryResponse:
+  internal_interfaces_http_handlers.PortfolioSummaryResponse:
     properties:
       asset_count:
         type: integer
       breakdown_by_type:
         items:
-          $ref: '#/definitions/handlers.AssetTypeBreakdownResponse'
+          $ref: '#/definitions/internal_interfaces_http_handlers.AssetTypeBreakdownResponse'
         type: array
       gain_loss:
         type: number
@@ -493,7 +579,7 @@ definitions:
       total_value:
         type: number
     type: object
-  handlers.RiskAlertResponse:
+  internal_interfaces_http_handlers.RiskAlertResponse:
     properties:
       message:
         example: El 45% de tu portafolio está en un solo sector
@@ -514,50 +600,59 @@ definitions:
         example: 45.5
         type: number
     type: object
-  handlers.SimulateRequest:
+  internal_interfaces_http_handlers.SimulateRequest:
+    properties:
+      parameters:
+        items:
+          type: integer
+        type: array
+      type:
+        type: string
+    required:
+    - type
     type: object
-  handlers.SimulateResponse:
+  internal_interfaces_http_handlers.SimulateResponse:
     properties:
       ai_analysis:
         type: string
       changes:
         items:
-          $ref: '#/definitions/entities.ChangeDetail'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ChangeDetail'
         type: array
       current_state:
-        $ref: '#/definitions/entities.PortfolioState'
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState'
       projected_state:
-        $ref: '#/definitions/entities.PortfolioState'
+        $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.PortfolioState'
       warnings:
         items:
           type: string
         type: array
     type: object
-  handlers.SyncRequest:
+  internal_interfaces_http_handlers.SyncRequest:
     properties:
       display_name:
         type: string
     type: object
-  handlers.SyncResponse:
+  internal_interfaces_http_handlers.SyncResponse:
     properties:
       created:
         type: boolean
       user:
-        $ref: '#/definitions/handlers.UserResponse'
+        $ref: '#/definitions/internal_interfaces_http_handlers.UserResponse'
     type: object
-  handlers.TemplatesResponse:
+  internal_interfaces_http_handlers.TemplatesResponse:
     properties:
       templates:
         items:
-          $ref: '#/definitions/entities.ScenarioTemplate'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_domain_entities.ScenarioTemplate'
         type: array
     type: object
-  handlers.UnreadCountResponse:
+  internal_interfaces_http_handlers.UnreadCountResponse:
     properties:
       count:
         type: integer
     type: object
-  handlers.UpdateAssetRequest:
+  internal_interfaces_http_handlers.UpdateAssetRequest:
     properties:
       currency:
         type: string
@@ -596,7 +691,7 @@ definitions:
         - other
         type: string
     type: object
-  handlers.UpdateConversationRequest:
+  internal_interfaces_http_handlers.UpdateConversationRequest:
     properties:
       title:
         maxLength: 255
@@ -605,7 +700,7 @@ definitions:
     required:
     - title
     type: object
-  handlers.UserResponse:
+  internal_interfaces_http_handlers.UserResponse:
     properties:
       avatar_url:
         type: string
@@ -620,7 +715,7 @@ definitions:
       updated_at:
         type: string
     type: object
-  handlers.WelcomeResponse:
+  internal_interfaces_http_handlers.WelcomeResponse:
     properties:
       conversation_starters:
         items:
@@ -628,51 +723,6 @@ definitions:
         type: array
       message:
         type: string
-    type: object
-  response.ErrorInfo:
-    properties:
-      code:
-        type: string
-      message:
-        type: string
-    type: object
-  response.Meta:
-    properties:
-      request_id:
-        type: string
-    type: object
-  response.Response:
-    properties:
-      data: {}
-      error:
-        $ref: '#/definitions/response.ErrorInfo'
-      meta:
-        $ref: '#/definitions/response.Meta'
-      success:
-        type: boolean
-    type: object
-  services.HistoricalStats:
-    properties:
-      average_return:
-        type: number
-      best_day:
-        type: number
-      data_points:
-        type: integer
-      max_drawdown:
-        type: number
-      negative_days:
-        type: integer
-      period:
-        type: string
-      positive_days:
-        type: integer
-      symbol:
-        type: string
-      volatility:
-        type: number
-      worst_day:
-        type: number
     type: object
 host: wealthscope-production.up.railway.app
 info:
@@ -713,7 +763,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.ChatRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.ChatRequest'
       produces:
       - application/json
       responses:
@@ -721,23 +771,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ChatResponseDTO'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.ChatResponseDTO'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Send a message to the AI
       tags:
       - AI
@@ -760,19 +810,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ConversationListResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.ConversationListResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: List conversations
       tags:
       - AI
@@ -786,7 +836,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.CreateConversationRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.CreateConversationRequest'
       produces:
       - application/json
       responses:
@@ -794,23 +844,23 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ConversationResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.ConversationResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Create a new conversation
       tags:
       - AI
@@ -829,23 +879,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Delete a conversation
       tags:
       - AI
@@ -864,27 +914,27 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ConversationWithMessagesResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.ConversationWithMessagesResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Get a conversation
       tags:
       - AI
@@ -903,30 +953,30 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.UpdateConversationRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.UpdateConversationRequest'
       produces:
       - application/json
       responses:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Update a conversation
       tags:
       - AI
@@ -965,19 +1015,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.InsightListResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.InsightListResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: List user insights
       tags:
       - AI Insights
@@ -997,27 +1047,27 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.InsightResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.InsightResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Get insight by ID
       tags:
       - AI Insights
@@ -1036,23 +1086,23 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Mark insight as read
       tags:
       - AI Insights
@@ -1066,19 +1116,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.InsightResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.InsightResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Get today's daily briefing
       tags:
       - AI Insights
@@ -1092,21 +1142,21 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
                   items:
-                    $ref: '#/definitions/handlers.InsightResponse'
+                    $ref: '#/definitions/internal_interfaces_http_handlers.InsightResponse'
                   type: array
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Generate new insights
       tags:
       - AI Insights
@@ -1120,19 +1170,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.UnreadCountResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.UnreadCountResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Get unread insight count
       tags:
       - AI Insights
@@ -1158,23 +1208,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/dto.OCRResponse'
+                  $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.OCRResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Process document with OCR
       tags:
       - AI OCR
@@ -1189,7 +1239,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/dto.ConfirmOCRAssetsRequest'
+          $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsRequest'
       produces:
       - application/json
       responses:
@@ -1197,23 +1247,23 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/dto.ConfirmOCRAssetsResponse'
+                  $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_dto.ConfirmOCRAssetsResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Create assets from OCR results
       tags:
       - AI OCR
@@ -1239,23 +1289,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/services.HistoricalStats'
+                  $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_internal_application_services.HistoricalStats'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Get historical statistics for a symbol
@@ -1272,15 +1322,15 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.TemplatesResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.TemplatesResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Get predefined scenario templates
@@ -1298,7 +1348,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.SimulateRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.SimulateRequest'
       produces:
       - application/json
       responses:
@@ -1306,23 +1356,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.SimulateResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.SimulateResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Run a what-if scenario simulation
@@ -1338,19 +1388,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.WelcomeResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.WelcomeResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       summary: Get welcome message
       tags:
       - AI
@@ -1385,19 +1435,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.ListAssetsResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.ListAssetsResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: List user's assets
@@ -1413,7 +1463,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.CreateAssetRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.CreateAssetRequest'
       produces:
       - application/json
       responses:
@@ -1421,23 +1471,23 @@ paths:
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AssetResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.AssetResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Create a new asset
@@ -1458,19 +1508,19 @@ paths:
         "200":
           description: OK
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Delete an asset
@@ -1491,23 +1541,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AssetResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.AssetResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Get asset by ID
@@ -1528,7 +1578,7 @@ paths:
         name: request
         required: true
         schema:
-          $ref: '#/definitions/handlers.UpdateAssetRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.UpdateAssetRequest'
       produces:
       - application/json
       responses:
@@ -1536,23 +1586,23 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.AssetResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.AssetResponse'
               type: object
         "400":
           description: Bad Request
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Update an asset
@@ -1568,19 +1618,19 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.UserResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.UserResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "404":
           description: Not Found
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Get current user
@@ -1596,7 +1646,7 @@ paths:
         in: body
         name: request
         schema:
-          $ref: '#/definitions/handlers.SyncRequest'
+          $ref: '#/definitions/internal_interfaces_http_handlers.SyncRequest'
       produces:
       - application/json
       responses:
@@ -1604,33 +1654,188 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.SyncResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.SyncResponse'
               type: object
         "201":
           description: Created
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.SyncResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.SyncResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
         "500":
           description: Internal Server Error
           schema:
-            $ref: '#/definitions/response.Response'
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
       security:
       - BearerAuth: []
       summary: Sync user from Supabase Auth
       tags:
       - auth
+  /api/v1/news:
+    get:
+      consumes:
+      - application/json
+      description: Fetch latest financial news with optional filtering by symbols,
+        keywords, language
+      parameters:
+      - description: Comma-separated stock symbols (e.g., AAPL,TSLA)
+        in: query
+        name: symbols
+        type: string
+      - description: Search keywords
+        in: query
+        name: q
+        type: string
+      - description: 'Language code (default: en)'
+        in: query
+        name: language
+        type: string
+      - description: Max articles (default 10, max 50)
+        in: query
+        name: limit
+        type: integer
+      - description: Page number (default 1)
+        in: query
+        name: page
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/internal_interfaces_http_handlers.NewsListResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+      summary: Get latest financial news
+      tags:
+      - News
+  /api/v1/news/search:
+    get:
+      consumes:
+      - application/json
+      description: Search for financial news articles by keywords
+      parameters:
+      - description: Search keywords
+        in: query
+        name: q
+        required: true
+        type: string
+      - description: Max articles (default 10, max 50)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/internal_interfaces_http_handlers.NewsListResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+      summary: Search financial news
+      tags:
+      - News
+  /api/v1/news/symbol/{symbol}:
+    get:
+      consumes:
+      - application/json
+      description: Fetch financial news related to a specific stock or crypto symbol
+      parameters:
+      - description: Stock symbol (e.g., AAPL)
+        in: path
+        name: symbol
+        required: true
+        type: string
+      - description: Max articles (default 10, max 50)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/internal_interfaces_http_handlers.NewsListResponse'
+              type: object
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+      summary: Get news for a specific symbol
+      tags:
+      - News
+  /api/v1/news/trending:
+    get:
+      consumes:
+      - application/json
+      description: Fetch top trending financial news articles
+      parameters:
+      - description: Max articles (default 10, max 50)
+        in: query
+        name: limit
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            allOf:
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+            - properties:
+                data:
+                  $ref: '#/definitions/internal_interfaces_http_handlers.NewsListResponse'
+              type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
+      summary: Get trending financial news
+      tags:
+      - News
   /api/v1/ping:
     get:
       description: Endpoint simple para verificar conectividad
@@ -1641,10 +1846,10 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.PingResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.PingResponse'
               type: object
       summary: Ping
       tags:
@@ -1659,16 +1864,16 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.PortfolioRiskResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.PortfolioRiskResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 error:
                   type: string
@@ -1677,7 +1882,7 @@ paths:
           description: Internal Server Error
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 error:
                   type: string
@@ -1697,16 +1902,16 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.PortfolioSummaryResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.PortfolioSummaryResponse'
               type: object
         "401":
           description: Unauthorized
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 error:
                   type: string
@@ -1715,7 +1920,7 @@ paths:
           description: Internal Server Error
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 error:
                   type: string
@@ -1736,10 +1941,10 @@ paths:
           description: OK
           schema:
             allOf:
-            - $ref: '#/definitions/response.Response'
+            - $ref: '#/definitions/github_com_Unikyri_WealthScope_backend_pkg_response.Response'
             - properties:
                 data:
-                  $ref: '#/definitions/handlers.HealthResponse'
+                  $ref: '#/definitions/internal_interfaces_http_handlers.HealthResponse'
               type: object
       summary: Health check
       tags:

--- a/backend/internal/interfaces/http/handlers/news.go
+++ b/backend/internal/interfaces/http/handlers/news.go
@@ -6,18 +6,18 @@ import (
 
 	"github.com/gin-gonic/gin"
 
-	"github.com/Unikyri/WealthScope/backend/internal/application/services"
-	domainsvc "github.com/Unikyri/WealthScope/backend/internal/domain/services"
+	appsvc "github.com/Unikyri/WealthScope/backend/internal/application/services"
+	"github.com/Unikyri/WealthScope/backend/internal/domain/services"
 	"github.com/Unikyri/WealthScope/backend/pkg/response"
 )
 
 // NewsHandler handles news-related HTTP requests.
 type NewsHandler struct {
-	newsService *services.NewsService
+	newsService *appsvc.NewsService
 }
 
 // NewNewsHandler creates a new NewsHandler.
-func NewNewsHandler(newsService *services.NewsService) *NewsHandler {
+func NewNewsHandler(newsService *appsvc.NewsService) *NewsHandler {
 	return &NewsHandler{
 		newsService: newsService,
 	}
@@ -25,19 +25,27 @@ func NewNewsHandler(newsService *services.NewsService) *NewsHandler {
 
 // NewsListResponse represents the response for news list endpoints.
 type NewsListResponse struct {
-	Articles []domainsvc.NewsArticle `json:"articles"`
-	Total    int                     `json:"total"`
-	Page     int                     `json:"page"`
-	Limit    int                     `json:"limit"`
+	Articles []services.NewsArticle `json:"articles"`
+	Total    int                    `json:"total"`
+	Page     int                    `json:"page"`
+	Limit    int                    `json:"limit"`
 }
 
 // GetNews handles GET /api/v1/news
-// Query parameters:
-//   - symbols: Comma-separated stock symbols (e.g., "AAPL,TSLA")
-//   - q: Search keywords
-//   - language: Language code (default "en")
-//   - limit: Max articles (default 10, max 50)
-//   - page: Pagination (default 1)
+// @Summary Get latest financial news
+// @Description Fetch latest financial news with optional filtering by symbols, keywords, language
+// @Tags News
+// @Accept json
+// @Produce json
+// @Param symbols query string false "Comma-separated stock symbols (e.g., AAPL,TSLA)"
+// @Param q query string false "Search keywords"
+// @Param language query string false "Language code (default: en)"
+// @Param limit query int false "Max articles (default 10, max 50)"
+// @Param page query int false "Page number (default 1)"
+// @Success 200 {object} response.Response{data=NewsListResponse}
+// @Failure 400 {object} response.Response
+// @Failure 500 {object} response.Response
+// @Router /api/v1/news [get]
 func (h *NewsHandler) GetNews(c *gin.Context) {
 	// Parse query parameters
 	symbolsParam := c.Query("symbols")
@@ -66,7 +74,7 @@ func (h *NewsHandler) GetNews(c *gin.Context) {
 	}
 
 	// Build query
-	query := domainsvc.NewsQuery{
+	query := services.NewsQuery{
 		Symbols:  symbols,
 		Keywords: keywords,
 		Language: language,
@@ -91,11 +99,17 @@ func (h *NewsHandler) GetNews(c *gin.Context) {
 }
 
 // GetNewsBySymbol handles GET /api/v1/news/symbol/:symbol
-// Path parameters:
-//   - symbol: Stock symbol (e.g., "AAPL")
-//
-// Query parameters:
-//   - limit: Max articles (default 10, max 50)
+// @Summary Get news for a specific symbol
+// @Description Fetch financial news related to a specific stock or crypto symbol
+// @Tags News
+// @Accept json
+// @Produce json
+// @Param symbol path string true "Stock symbol (e.g., AAPL)"
+// @Param limit query int false "Max articles (default 10, max 50)"
+// @Success 200 {object} response.Response{data=NewsListResponse}
+// @Failure 400 {object} response.Response
+// @Failure 500 {object} response.Response
+// @Router /api/v1/news/symbol/{symbol} [get]
 func (h *NewsHandler) GetNewsBySymbol(c *gin.Context) {
 	symbol := strings.TrimSpace(strings.ToUpper(c.Param("symbol")))
 	if symbol == "" {
@@ -128,8 +142,15 @@ func (h *NewsHandler) GetNewsBySymbol(c *gin.Context) {
 }
 
 // GetTrendingNews handles GET /api/v1/news/trending
-// Query parameters:
-//   - limit: Max articles (default 10, max 50)
+// @Summary Get trending financial news
+// @Description Fetch top trending financial news articles
+// @Tags News
+// @Accept json
+// @Produce json
+// @Param limit query int false "Max articles (default 10, max 50)"
+// @Success 200 {object} response.Response{data=NewsListResponse}
+// @Failure 500 {object} response.Response
+// @Router /api/v1/news/trending [get]
 func (h *NewsHandler) GetTrendingNews(c *gin.Context) {
 	limit, err := strconv.Atoi(c.DefaultQuery("limit", "10"))
 	if err != nil || limit <= 0 {
@@ -156,9 +177,17 @@ func (h *NewsHandler) GetTrendingNews(c *gin.Context) {
 }
 
 // SearchNews handles GET /api/v1/news/search
-// Query parameters:
-//   - q: Search keywords (required)
-//   - limit: Max articles (default 10, max 50)
+// @Summary Search financial news
+// @Description Search for financial news articles by keywords
+// @Tags News
+// @Accept json
+// @Produce json
+// @Param q query string true "Search keywords"
+// @Param limit query int false "Max articles (default 10, max 50)"
+// @Success 200 {object} response.Response{data=NewsListResponse}
+// @Failure 400 {object} response.Response
+// @Failure 500 {object} response.Response
+// @Router /api/v1/news/search [get]
 func (h *NewsHandler) SearchNews(c *gin.Context) {
 	keywords := c.Query("q")
 	if keywords == "" {


### PR DESCRIPTION
## Summary

Fixes missing Swagger documentation for News API endpoints.

## Changes

- Added Swagger annotations to `NewsHandler`:
  - `GET /api/v1/news`
  - `GET /api/v1/news/trending`
  - `GET /api/v1/news/search`
  - `GET /api/v1/news/symbol/:symbol`
- Refactored imports in `backend/internal/interfaces/http/handlers/news.go` to solve `swag init` parsing issues.
- Regenerated Swagger documentation.

## Verification

- `swag init` runs successfully.
- `go build` and `golangci-lint` pass.
- `docs/swagger.json` now includes News endpoints.