### PR TITLE
feat: US-14 Inject Portfolio Context into AI Chat

### DIFF
--- a/backend/internal/interfaces/http/router.go
+++ b/backend/internal/interfaces/http/router.go
@@ -119,7 +119,7 @@ func NewRouter(deps RouterDeps) *gin.Engine {
 	// Initialize chat handler
 	var chatHandler *handlers.ChatHandler
 	if deps.AIService != nil {
-		chatHandler = handlers.NewChatHandler(deps.AIService)
+		chatHandler = handlers.NewChatHandler(deps.AIService, assetRepo)
 	}
 
 	// Initialize insights handler


### PR DESCRIPTION
## US-14: Backend Context Injection (Critical Fix)

---

### Problem
The AI chatbot was operating **blind** — it could not access the user's real portfolio data.

**Before:**
```go
userCtx := ai.UserContext{
    HasPortfolio: false, // TODO: Get from portfolio service
}
```

### Solution
Injected `AssetRepository` into `ChatHandler` and created `buildUserContext` helper that fetches real portfolio data:
- `TotalValue`
- `AssetCount`
- `TopAssetTypes` (asset types with >= 10% allocation)

### Changes
- **chat.go**: Added `assetRepo` field, `buildUserContext` method
- **router.go**: Pass `assetRepo` to `NewChatHandler`

### Verification
```
✓ go build ./...
```