### PR TITLE
feat: US-12 Morning Briefing & Chain Results UI

### DIFF
--- a/frontend/lib/core/router/app_router.dart
+++ b/frontend/lib/core/router/app_router.dart
@@ -10,6 +10,7 @@ import 'package:wealthscope_app/features/auth/presentation/screens/login_screen.
 import 'package:wealthscope_app/features/auth/presentation/screens/register_screen.dart';
 import 'package:wealthscope_app/features/ai/presentation/screens/ai_advisor_screen.dart';
 import 'package:wealthscope_app/features/ai/presentation/screens/ai_chat_screen.dart';
+import 'package:wealthscope_app/features/ai/presentation/screens/briefing_screen.dart';
 import 'package:wealthscope_app/features/ai/presentation/screens/document_upload_screen.dart';
 import 'package:wealthscope_app/features/ai/presentation/screens/what_if_screen.dart';
 import 'package:wealthscope_app/features/conversations/presentation/screens/conversation_chat_screen.dart';
@@ -129,6 +130,11 @@ class AppRouter {
             path: '/ai-advisor',
             name: 'ai-advisor',
             builder: (context, state) => const AIAdvisorScreen(),
+          ),
+          GoRoute(
+            path: '/ai-briefing',
+            name: 'ai-briefing',
+            builder: (context, state) => const BriefingScreen(),
           ),
           GoRoute(
             path: '/ai-chat',

--- a/frontend/lib/features/ai/presentation/screens/ai_advisor_screen.dart
+++ b/frontend/lib/features/ai/presentation/screens/ai_advisor_screen.dart
@@ -36,6 +36,16 @@ class AIAdvisorScreen extends StatelessWidget {
             ),
             const SizedBox(height: 32),
 
+            // Morning Briefing Card (NEW!)
+            _FeatureCard(
+              icon: Icons.wb_sunny_outlined,
+              iconColor: Colors.amber,
+              title: 'Morning Briefing',
+              description: 'Get your personalized daily financial briefing with AI-powered insights and portfolio updates.',
+              onTap: () => context.push('/ai-briefing'),
+            ),
+            const SizedBox(height: 16),
+
             // AI Chat Card
             _FeatureCard(
               icon: Icons.chat_bubble_outline,

--- a/frontend/lib/features/ai/presentation/screens/briefing_screen.dart
+++ b/frontend/lib/features/ai/presentation/screens/briefing_screen.dart
@@ -1,0 +1,557 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/briefing.dart';
+import '../widgets/briefing_bottom_sheet.dart';
+
+/// Screen that displays the AI Morning Briefing.
+/// Fetches data and displays it via the MorningBriefingBottomSheet widget.
+class BriefingScreen extends ConsumerStatefulWidget {
+  const BriefingScreen({super.key});
+
+  @override
+  ConsumerState<BriefingScreen> createState() => _BriefingScreenState();
+}
+
+class _BriefingScreenState extends ConsumerState<BriefingScreen> {
+  bool _isLoading = true;
+  Briefing? _briefing;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadBriefing();
+  }
+
+  Future<void> _loadBriefing() async {
+    setState(() {
+      _isLoading = true;
+      _error = null;
+    });
+
+    // TODO: Replace with actual API call when backend endpoint is ready
+    // For now, use demo data
+    await Future.delayed(const Duration(seconds: 1));
+
+    setState(() {
+      _isLoading = false;
+      _briefing = _createDemoBriefing();
+    });
+  }
+
+  Briefing _createDemoBriefing() {
+    return Briefing(
+      summary: 'Your portfolio is performing well today! Tech stocks are driving most of your gains. '
+          'Consider taking some profits on your overweight positions.',
+      insights: [
+        BriefingInsight(
+          type: 'market',
+          title: 'Tech Rally Continues',
+          description: 'Technology sector is up 2.3% driven by strong earnings reports.',
+          changePercent: 2.3,
+        ),
+        BriefingInsight(
+          type: 'opportunity',
+          title: 'Rebalancing Opportunity',
+          description: 'Your crypto allocation is 5% above target. Consider taking profits.',
+          changePercent: null,
+        ),
+        BriefingInsight(
+          type: 'risk',
+          title: 'Bond Volatility Alert',
+          description: 'Interest rate sensitivity of your bond holdings has increased.',
+          changePercent: -0.8,
+        ),
+      ],
+      alerts: [
+        BriefingAlert(
+          severity: 'medium',
+          message: 'AAPL is up 15% this month - consider profit-taking.',
+          assetId: 'aapl',
+        ),
+        BriefingAlert(
+          severity: 'low',
+          message: 'Your emergency fund contribution is due in 3 days.',
+          assetId: null,
+        ),
+      ],
+      portfolioSnapshot: PortfolioSnapshot(
+        totalValue: 127543.67,
+        dayChange: 1283.45,
+        dayChangePercent: 1.02,
+        assetCount: 12,
+        topAssets: ['AAPL', 'MSFT', 'BTC'],
+      ),
+      generatedAt: DateTime.now(),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Morning Briefing'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: _loadBriefing,
+            tooltip: 'Refresh',
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? _buildLoadingState(colorScheme, textTheme)
+          : _error != null
+              ? _buildErrorState(colorScheme, textTheme)
+              : _briefing != null
+                  ? SingleChildScrollView(
+                      child: Padding(
+                        padding: const EdgeInsets.all(16),
+                        child: _BriefingContent(briefing: _briefing!),
+                      ),
+                    )
+                  : const SizedBox.shrink(),
+    );
+  }
+
+  Widget _buildLoadingState(ColorScheme colorScheme, TextTheme textTheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 80,
+            height: 80,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [colorScheme.primary, colorScheme.tertiary],
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+              ),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: const Center(
+              child: SizedBox(
+                width: 40,
+                height: 40,
+                child: CircularProgressIndicator(
+                  color: Colors.white,
+                  strokeWidth: 3,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 24),
+          Text(
+            'Preparing your briefing...',
+            style: textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Analyzing your portfolio and market trends',
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildErrorState(ColorScheme colorScheme, TextTheme textTheme) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Icon(
+            Icons.error_outline,
+            size: 64,
+            color: colorScheme.error,
+          ),
+          const SizedBox(height: 16),
+          Text(
+            'Failed to load briefing',
+            style: textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            _error ?? 'Unknown error',
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+          const SizedBox(height: 24),
+          FilledButton.icon(
+            onPressed: _loadBriefing,
+            icon: const Icon(Icons.refresh),
+            label: const Text('Retry'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// The main content of the briefing, displayed within the screen.
+class _BriefingContent extends StatelessWidget {
+  final Briefing briefing;
+
+  const _BriefingContent({required this.briefing});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    final hour = DateTime.now().hour;
+    String greeting;
+    IconData icon;
+
+    if (hour < 12) {
+      greeting = 'Good Morning';
+      icon = Icons.wb_sunny_outlined;
+    } else if (hour < 17) {
+      greeting = 'Good Afternoon';
+      icon = Icons.wb_cloudy_outlined;
+    } else {
+      greeting = 'Good Evening';
+      icon = Icons.nights_stay_outlined;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        // Header
+        Row(
+          children: [
+            Container(
+              width: 48,
+              height: 48,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: [colorScheme.primary, colorScheme.tertiary],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
+                borderRadius: BorderRadius.circular(12),
+              ),
+              child: Icon(icon, color: Colors.white, size: 24),
+            ),
+            const SizedBox(width: 16),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    greeting,
+                    style: textTheme.titleLarge?.copyWith(
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    'Here\'s your financial briefing',
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 24),
+
+        // Portfolio Snapshot
+        _buildPortfolioCard(colorScheme, textTheme),
+        const SizedBox(height: 20),
+
+        // AI Summary
+        _buildSummarySection(colorScheme, textTheme),
+        const SizedBox(height: 24),
+
+        // Alerts
+        if (briefing.alerts.isNotEmpty) ...[
+          _buildAlertsSection(colorScheme, textTheme),
+          const SizedBox(height: 24),
+        ],
+
+        // Insights
+        if (briefing.insights.isNotEmpty) _buildInsightsSection(colorScheme, textTheme),
+      ],
+    );
+  }
+
+  Widget _buildPortfolioCard(ColorScheme colorScheme, TextTheme textTheme) {
+    final snapshot = briefing.portfolioSnapshot;
+    final isPositive = snapshot.dayChange >= 0;
+    final changeColor = isPositive ? Colors.green : Colors.red;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primaryContainer,
+            colorScheme.primaryContainer.withAlpha(180),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withAlpha(30),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Portfolio Value',
+            style: textTheme.labelLarge?.copyWith(
+              color: colorScheme.onPrimaryContainer.withAlpha(180),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '\$${_formatNumber(snapshot.totalValue)}',
+            style: textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Icon(
+                isPositive ? Icons.trending_up : Icons.trending_down,
+                color: changeColor,
+                size: 20,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                '${isPositive ? '+' : ''}\$${_formatNumber(snapshot.dayChange.abs())} (${snapshot.dayChangePercent.toStringAsFixed(2)}%)',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: changeColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colorScheme.onPrimaryContainer.withAlpha(20),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '${snapshot.assetCount} assets',
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummarySection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.auto_awesome, color: colorScheme.primary, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'AI Summary',
+              style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest.withAlpha(100),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: colorScheme.outlineVariant.withAlpha(50)),
+          ),
+          child: Text(
+            briefing.summary.isEmpty
+                ? 'Your portfolio is performing steadily. No major changes detected today.'
+                : briefing.summary,
+            style: textTheme.bodyMedium?.copyWith(height: 1.5),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAlertsSection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.notifications_active, color: Colors.orange, size: 20),
+            const SizedBox(width: 8),
+            Text('Alerts', style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...briefing.alerts.map((alert) => _buildAlertCard(alert, colorScheme, textTheme)),
+      ],
+    );
+  }
+
+  Widget _buildAlertCard(BriefingAlert alert, ColorScheme colorScheme, TextTheme textTheme) {
+    Color alertColor;
+    IconData alertIcon;
+
+    switch (alert.severity.toLowerCase()) {
+      case 'high':
+        alertColor = Colors.red;
+        alertIcon = Icons.error;
+      case 'medium':
+        alertColor = Colors.orange;
+        alertIcon = Icons.warning;
+      default:
+        alertColor = Colors.blue;
+        alertIcon = Icons.info;
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: alertColor.withAlpha(20),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: alertColor.withAlpha(50)),
+      ),
+      child: Row(
+        children: [
+          Icon(alertIcon, color: alertColor, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(alert.message, style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurface)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInsightsSection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            const Icon(Icons.lightbulb_outline, color: Colors.amber, size: 20),
+            const SizedBox(width: 8),
+            Text('Today\'s Insights', style: textTheme.titleMedium?.copyWith(fontWeight: FontWeight.bold)),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...briefing.insights.map((insight) => _buildInsightCard(insight, colorScheme, textTheme)),
+      ],
+    );
+  }
+
+  Widget _buildInsightCard(BriefingInsight insight, ColorScheme colorScheme, TextTheme textTheme) {
+    Color typeColor;
+    IconData typeIcon;
+
+    switch (insight.type.toLowerCase()) {
+      case 'market':
+        typeColor = Colors.blue;
+        typeIcon = Icons.show_chart;
+      case 'opportunity':
+        typeColor = Colors.green;
+        typeIcon = Icons.trending_up;
+      case 'risk':
+        typeColor = Colors.orange;
+        typeIcon = Icons.shield_outlined;
+      default:
+        typeColor = colorScheme.primary;
+        typeIcon = Icons.insights;
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outlineVariant.withAlpha(80)),
+        boxShadow: [
+          BoxShadow(color: Colors.black.withAlpha(8), blurRadius: 8, offset: const Offset(0, 2)),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: typeColor.withAlpha(25),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(typeIcon, color: typeColor, size: 16),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(insight.title, style: textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600)),
+              ),
+              if (insight.changePercent != null)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: (insight.changePercent! >= 0 ? Colors.green : Colors.red).withAlpha(20),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    '${insight.changePercent! >= 0 ? '+' : ''}${insight.changePercent!.toStringAsFixed(1)}%',
+                    style: textTheme.labelSmall?.copyWith(
+                      color: insight.changePercent! >= 0 ? Colors.green : Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            insight.description,
+            style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant, height: 1.4),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatNumber(double value) {
+    if (value >= 1000000) {
+      return '${(value / 1000000).toStringAsFixed(2)}M';
+    } else if (value >= 1000) {
+      return '${(value / 1000).toStringAsFixed(1)}K';
+    }
+    return value.toStringAsFixed(2);
+  }
+}

--- a/frontend/lib/features/ai/presentation/widgets/briefing_bottom_sheet.dart
+++ b/frontend/lib/features/ai/presentation/widgets/briefing_bottom_sheet.dart
@@ -1,0 +1,447 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../domain/entities/briefing.dart';
+
+/// A beautiful bottom sheet that displays the AI Morning Briefing.
+class MorningBriefingBottomSheet extends ConsumerWidget {
+  final Briefing briefing;
+
+  const MorningBriefingBottomSheet({
+    super.key,
+    required this.briefing,
+  });
+
+  /// Shows the briefing bottom sheet.
+  static Future<void> show(BuildContext context, Briefing briefing) {
+    return showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      showDragHandle: true,
+      useSafeArea: true,
+      backgroundColor: Theme.of(context).colorScheme.surface,
+      builder: (context) => MorningBriefingBottomSheet(briefing: briefing),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return DraggableScrollableSheet(
+      initialChildSize: 0.85,
+      maxChildSize: 0.95,
+      minChildSize: 0.5,
+      expand: false,
+      builder: (context, scrollController) {
+        return SingleChildScrollView(
+          controller: scrollController,
+          padding: const EdgeInsets.fromLTRB(20, 0, 20, 32),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header with greeting
+              _buildHeader(context, colorScheme, textTheme),
+              const SizedBox(height: 24),
+
+              // Portfolio Snapshot Card
+              _buildPortfolioCard(context, colorScheme, textTheme),
+              const SizedBox(height: 20),
+
+              // AI Summary
+              _buildSummarySection(colorScheme, textTheme),
+              const SizedBox(height: 24),
+
+              // Alerts Section
+              if (briefing.alerts.isNotEmpty) ...[
+                _buildAlertsSection(colorScheme, textTheme),
+                const SizedBox(height: 24),
+              ],
+
+              // Insights Section
+              if (briefing.insights.isNotEmpty)
+                _buildInsightsSection(colorScheme, textTheme),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildHeader(
+    BuildContext context,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final hour = DateTime.now().hour;
+    String greeting;
+    IconData icon;
+
+    if (hour < 12) {
+      greeting = 'Good Morning';
+      icon = Icons.wb_sunny_outlined;
+    } else if (hour < 17) {
+      greeting = 'Good Afternoon';
+      icon = Icons.wb_cloudy_outlined;
+    } else {
+      greeting = 'Good Evening';
+      icon = Icons.nights_stay_outlined;
+    }
+
+    return Row(
+      children: [
+        Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [colorScheme.primary, colorScheme.tertiary],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(icon, color: Colors.white, size: 24),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                greeting,
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Text(
+                'Here\'s your financial briefing',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildPortfolioCard(
+    BuildContext context,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final snapshot = briefing.portfolioSnapshot;
+    final isPositive = snapshot.dayChange >= 0;
+    final changeColor = isPositive ? Colors.green : Colors.red;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [
+            colorScheme.primaryContainer,
+            colorScheme.primaryContainer.withAlpha(180),
+          ],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: colorScheme.primary.withAlpha(30),
+            blurRadius: 12,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Portfolio Value',
+            style: textTheme.labelLarge?.copyWith(
+              color: colorScheme.onPrimaryContainer.withAlpha(180),
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            '\$${_formatNumber(snapshot.totalValue)}',
+            style: textTheme.headlineMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: colorScheme.onPrimaryContainer,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Icon(
+                isPositive ? Icons.trending_up : Icons.trending_down,
+                color: changeColor,
+                size: 20,
+              ),
+              const SizedBox(width: 4),
+              Text(
+                '${isPositive ? '+' : ''}\$${_formatNumber(snapshot.dayChange.abs())} (${snapshot.dayChangePercent.toStringAsFixed(2)}%)',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: changeColor,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const Spacer(),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: colorScheme.onPrimaryContainer.withAlpha(20),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Text(
+                  '${snapshot.assetCount} assets',
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onPrimaryContainer,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSummarySection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.auto_awesome, color: colorScheme.primary, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'AI Summary',
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest.withAlpha(100),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: colorScheme.outlineVariant.withAlpha(50),
+            ),
+          ),
+          child: Text(
+            briefing.summary.isEmpty
+                ? 'Your portfolio is performing steadily. No major changes detected today.'
+                : briefing.summary,
+            style: textTheme.bodyMedium?.copyWith(
+              height: 1.5,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildAlertsSection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.notifications_active, color: Colors.orange, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'Alerts',
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...briefing.alerts.map((alert) => _buildAlertCard(alert, colorScheme, textTheme)),
+      ],
+    );
+  }
+
+  Widget _buildAlertCard(
+    BriefingAlert alert,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    Color alertColor;
+    IconData alertIcon;
+
+    switch (alert.severity.toLowerCase()) {
+      case 'high':
+        alertColor = Colors.red;
+        alertIcon = Icons.error;
+        break;
+      case 'medium':
+        alertColor = Colors.orange;
+        alertIcon = Icons.warning;
+        break;
+      default:
+        alertColor = Colors.blue;
+        alertIcon = Icons.info;
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: alertColor.withAlpha(20),
+        borderRadius: BorderRadius.circular(10),
+        border: Border.all(color: alertColor.withAlpha(50)),
+      ),
+      child: Row(
+        children: [
+          Icon(alertIcon, color: alertColor, size: 20),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              alert.message,
+              style: textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurface,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInsightsSection(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.lightbulb_outline, color: Colors.amber, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'Today\'s Insights',
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        ...briefing.insights.map((insight) => _buildInsightCard(insight, colorScheme, textTheme)),
+      ],
+    );
+  }
+
+  Widget _buildInsightCard(
+    BriefingInsight insight,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    Color typeColor;
+    IconData typeIcon;
+
+    switch (insight.type.toLowerCase()) {
+      case 'market':
+        typeColor = Colors.blue;
+        typeIcon = Icons.show_chart;
+        break;
+      case 'opportunity':
+        typeColor = Colors.green;
+        typeIcon = Icons.trending_up;
+        break;
+      case 'risk':
+        typeColor = Colors.orange;
+        typeIcon = Icons.shield_outlined;
+        break;
+      default:
+        typeColor = colorScheme.primary;
+        typeIcon = Icons.insights;
+    }
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: colorScheme.outlineVariant.withAlpha(80)),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withAlpha(8),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(6),
+                decoration: BoxDecoration(
+                  color: typeColor.withAlpha(25),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(typeIcon, color: typeColor, size: 16),
+              ),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Text(
+                  insight.title,
+                  style: textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+              if (insight.changePercent != null)
+                Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                  decoration: BoxDecoration(
+                    color: (insight.changePercent! >= 0 ? Colors.green : Colors.red)
+                        .withAlpha(20),
+                    borderRadius: BorderRadius.circular(6),
+                  ),
+                  child: Text(
+                    '${insight.changePercent! >= 0 ? '+' : ''}${insight.changePercent!.toStringAsFixed(1)}%',
+                    style: textTheme.labelSmall?.copyWith(
+                      color: insight.changePercent! >= 0 ? Colors.green : Colors.red,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Text(
+            insight.description,
+            style: textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+              height: 1.4,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatNumber(double value) {
+    if (value >= 1000000) {
+      return '${(value / 1000000).toStringAsFixed(2)}M';
+    } else if (value >= 1000) {
+      return '${(value / 1000).toStringAsFixed(1)}K';
+    }
+    return value.toStringAsFixed(2);
+  }
+}

--- a/frontend/lib/features/ai/presentation/widgets/chain_results_view.dart
+++ b/frontend/lib/features/ai/presentation/widgets/chain_results_view.dart
@@ -1,0 +1,484 @@
+import 'package:flutter/material.dart';
+import '../../domain/entities/chain_result.dart';
+
+/// Widget that displays the results of a chain scenario simulation.
+class ChainResultsView extends StatelessWidget {
+  final ChainResult result;
+  final VoidCallback? onDismiss;
+
+  const ChainResultsView({
+    super.key,
+    required this.result,
+    this.onDismiss,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: colorScheme.surface,
+        borderRadius: const BorderRadius.vertical(top: Radius.circular(24)),
+      ),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          // Handle bar
+          Container(
+            margin: const EdgeInsets.only(top: 12),
+            width: 40,
+            height: 4,
+            decoration: BoxDecoration(
+              color: colorScheme.outlineVariant,
+              borderRadius: BorderRadius.circular(2),
+            ),
+          ),
+
+          Expanded(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Header
+                  _buildHeader(colorScheme, textTheme),
+                  const SizedBox(height: 24),
+
+                  // Cumulative Impact Card
+                  _buildCumulativeImpactCard(colorScheme, textTheme),
+                  const SizedBox(height: 24),
+
+                  // Steps Timeline
+                  _buildStepsTimeline(colorScheme, textTheme),
+                  const SizedBox(height: 24),
+
+                  // Risk Assessment
+                  _buildRiskAssessment(colorScheme, textTheme),
+                  const SizedBox(height: 24),
+
+                  // AI Explanation
+                  _buildAIExplanation(colorScheme, textTheme),
+                  const SizedBox(height: 32),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(ColorScheme colorScheme, TextTheme textTheme) {
+    return Row(
+      children: [
+        Container(
+          width: 48,
+          height: 48,
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              colors: [Colors.purple, Colors.indigo],
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: const Icon(Icons.route, color: Colors.white, size: 24),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Chain Simulation',
+                style: textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              Text(
+                '${result.steps.length} scenarios simulated',
+                style: textTheme.bodyMedium?.copyWith(
+                  color: colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCumulativeImpactCard(ColorScheme colorScheme, TextTheme textTheme) {
+    final impact = result.cumulativeImpact;
+    final isPositive = impact.absoluteChange >= 0;
+    final changeColor = isPositive ? Colors.green : Colors.red;
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: isPositive
+              ? [Colors.green.shade50, Colors.green.shade100]
+              : [Colors.red.shade50, Colors.red.shade100],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(color: changeColor.withAlpha(40)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Cumulative Impact',
+            style: textTheme.labelLarge?.copyWith(
+              color: changeColor.shade700,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      '${isPositive ? '+' : ''}\$${_formatNumber(impact.absoluteChange)}',
+                      style: textTheme.headlineMedium?.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: changeColor.shade800,
+                      ),
+                    ),
+                    Text(
+                      '${isPositive ? '+' : ''}${impact.percentChange.toStringAsFixed(2)}% change',
+                      style: textTheme.bodyMedium?.copyWith(
+                        color: changeColor.shade700,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Icon(
+                isPositive ? Icons.trending_up : Icons.trending_down,
+                color: changeColor,
+                size: 48,
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              _buildValueLabel('Before', impact.valueBefore, colorScheme, textTheme),
+              Icon(Icons.arrow_forward, color: changeColor, size: 20),
+              _buildValueLabel('After', impact.valueAfter, colorScheme, textTheme),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildValueLabel(
+    String label,
+    double value,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    return Column(
+      children: [
+        Text(
+          label,
+          style: textTheme.labelSmall?.copyWith(
+            color: colorScheme.onSurfaceVariant,
+          ),
+        ),
+        Text(
+          '\$${_formatNumber(value)}',
+          style: textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.bold,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildStepsTimeline(ColorScheme colorScheme, TextTheme textTheme) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.timeline, color: colorScheme.primary, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'Scenario Steps',
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 16),
+        ...result.steps.asMap().entries.map((entry) {
+          final index = entry.key;
+          final step = entry.value;
+          final isLast = index == result.steps.length - 1;
+          return _buildStepCard(step, index, isLast, colorScheme, textTheme);
+        }),
+      ],
+    );
+  }
+
+  Widget _buildStepCard(
+    ChainStep step,
+    int index,
+    bool isLast,
+    ColorScheme colorScheme,
+    TextTheme textTheme,
+  ) {
+    final isPositive = step.impact.absoluteChange >= 0;
+    final changeColor = isPositive ? Colors.green : Colors.red;
+
+    return IntrinsicHeight(
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Timeline indicator
+          SizedBox(
+            width: 40,
+            child: Column(
+              children: [
+                Container(
+                  width: 32,
+                  height: 32,
+                  decoration: BoxDecoration(
+                    color: colorScheme.primaryContainer,
+                    shape: BoxShape.circle,
+                  ),
+                  child: Center(
+                    child: Text(
+                      '${index + 1}',
+                      style: textTheme.labelLarge?.copyWith(
+                        color: colorScheme.onPrimaryContainer,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                ),
+                if (!isLast)
+                  Expanded(
+                    child: Container(
+                      width: 2,
+                      color: colorScheme.outlineVariant,
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          // Step content
+          Expanded(
+            child: Container(
+              margin: EdgeInsets.only(bottom: isLast ? 0 : 16),
+              padding: const EdgeInsets.all(16),
+              decoration: BoxDecoration(
+                color: colorScheme.surfaceContainerHighest.withAlpha(80),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: colorScheme.outlineVariant.withAlpha(50)),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          step.scenarioType.replaceAll('_', ' ').toUpperCase(),
+                          style: textTheme.labelMedium?.copyWith(
+                            color: colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: changeColor.withAlpha(30),
+                          borderRadius: BorderRadius.circular(6),
+                        ),
+                        child: Text(
+                          '${isPositive ? '+' : ''}${step.impact.percentChange.toStringAsFixed(1)}%',
+                          style: textTheme.labelSmall?.copyWith(
+                            color: changeColor,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                  if (step.description.isNotEmpty) ...[
+                    const SizedBox(height: 8),
+                    Text(
+                      step.description,
+                      style: textTheme.bodySmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRiskAssessment(ColorScheme colorScheme, TextTheme textTheme) {
+    final risk = result.riskAssessment;
+    Color riskColor;
+    IconData riskIcon;
+
+    switch (risk.level.toLowerCase()) {
+      case 'high':
+        riskColor = Colors.red;
+        riskIcon = Icons.warning_amber;
+        break;
+      case 'medium':
+        riskColor = Colors.orange;
+        riskIcon = Icons.info_outline;
+        break;
+      default:
+        riskColor = Colors.green;
+        riskIcon = Icons.check_circle_outline;
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: riskColor.withAlpha(15),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: riskColor.withAlpha(40)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(riskIcon, color: riskColor, size: 24),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Risk Assessment: ${risk.level.toUpperCase()}',
+                      style: textTheme.titleSmall?.copyWith(
+                        color: riskColor,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Score: ${risk.score}/100',
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (risk.summary.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            Text(
+              risk.summary,
+              style: textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurface,
+              ),
+            ),
+          ],
+          if (risk.warnings.isNotEmpty) ...[
+            const SizedBox(height: 12),
+            ...risk.warnings.map((w) => Padding(
+              padding: const EdgeInsets.only(bottom: 4),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Icon(Icons.warning, color: Colors.orange, size: 14),
+                  const SizedBox(width: 6),
+                  Expanded(
+                    child: Text(
+                      w,
+                      style: textTheme.labelSmall?.copyWith(
+                        color: colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            )),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAIExplanation(ColorScheme colorScheme, TextTheme textTheme) {
+    if (result.aiExplanation.isEmpty) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          children: [
+            Icon(Icons.auto_awesome, color: colorScheme.primary, size: 20),
+            const SizedBox(width: 8),
+            Text(
+              'AI Analysis',
+              style: textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ],
+        ),
+        const SizedBox(height: 12),
+        Container(
+          width: double.infinity,
+          padding: const EdgeInsets.all(16),
+          decoration: BoxDecoration(
+            color: colorScheme.surfaceContainerHighest.withAlpha(80),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(color: colorScheme.outlineVariant.withAlpha(50)),
+          ),
+          child: Text(
+            result.aiExplanation,
+            style: textTheme.bodyMedium?.copyWith(
+              height: 1.5,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _formatNumber(double value) {
+    if (value.abs() >= 1000000) {
+      return '${(value / 1000000).toStringAsFixed(2)}M';
+    } else if (value.abs() >= 1000) {
+      return '${(value / 1000).toStringAsFixed(1)}K';
+    }
+    return value.toStringAsFixed(2);
+  }
+}
+
+extension _ColorBrightness on Color {
+  Color get shade700 => HSLColor.fromColor(this).withLightness(0.35).toColor();
+  Color get shade800 => HSLColor.fromColor(this).withLightness(0.25).toColor();
+}


### PR DESCRIPTION
## US-12: UI Implementation

---

### Summary
Adds Morning Briefing screen and Chain Results visualization for hackathon demo.

### New Files
- **`briefing_screen.dart`**: Full-screen Morning Briefing with loading states and demo data
- **`briefing_bottom_sheet.dart`**: Bottom sheet variant of Morning Briefing (portfolio snapshot, AI summary, alerts, insights)
- **`chain_results_view.dart`**: Chain scenario results with timeline visualization, cumulative impact, risk assessment, AI analysis

### Modified Files
- **`ai_advisor_screen.dart`**: Added Morning Briefing card
- **`app_router.dart`**: Added `/ai-briefing` route

### Demo Features
- Beautiful gradient cards and premium styling
- Time-aware greeting (Good Morning/Afternoon/Evening)
- Built-in demo data for hackathon presentation
- Loading states with animations