### PR TITLE
refactor: Remove mock data from BriefingScreen, connect to real API

### DIFF
--- a/frontend/lib/features/ai/presentation/providers/briefing_provider.dart
+++ b/frontend/lib/features/ai/presentation/providers/briefing_provider.dart
@@ -1,0 +1,72 @@
+import 'package:riverpod_annotation/riverpod_annotation.dart';
+import '../../domain/entities/briefing.dart';
+import 'ai_chat_provider.dart';
+
+part 'briefing_provider.g.dart';
+
+/// State for the briefing
+class BriefingState {
+  final bool isLoading;
+  final Briefing? briefing;
+  final String? error;
+
+  const BriefingState({
+    this.isLoading = false,
+    this.briefing,
+    this.error,
+  });
+
+  BriefingState copyWith({
+    bool? isLoading,
+    Briefing? briefing,
+    String? error,
+  }) {
+    return BriefingState(
+      isLoading: isLoading ?? this.isLoading,
+      briefing: briefing ?? this.briefing,
+      error: error,
+    );
+  }
+}
+
+/// Provider for managing briefing state
+@riverpod
+class BriefingNotifier extends _$BriefingNotifier {
+  @override
+  BriefingState build() {
+    return const BriefingState();
+  }
+
+  /// Load briefing from the API
+  Future<void> loadBriefing() async {
+    state = state.copyWith(isLoading: true, error: null);
+
+    try {
+      final repository = ref.read(aiRepositoryProvider);
+      final result = await repository.getBriefing();
+
+      result.fold(
+        (failure) {
+          state = state.copyWith(
+            isLoading: false,
+            error: failure.message,
+          );
+        },
+        (briefing) {
+          state = state.copyWith(
+            isLoading: false,
+            briefing: briefing,
+          );
+        },
+      );
+    } catch (e) {
+      state = state.copyWith(
+        isLoading: false,
+        error: e.toString(),
+      );
+    }
+  }
+
+  /// Refresh the briefing
+  Future<void> refresh() => loadBriefing();
+}

--- a/frontend/lib/features/ai/presentation/providers/briefing_provider.g.dart
+++ b/frontend/lib/features/ai/presentation/providers/briefing_provider.g.dart
@@ -1,0 +1,28 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'briefing_provider.dart';
+
+// **************************************************************************
+// RiverpodGenerator
+// **************************************************************************
+
+String _$briefingNotifierHash() => r'665c48cab4758b638495747b25b2d113ec1e8342';
+
+/// Provider for managing briefing state
+///
+/// Copied from [BriefingNotifier].
+@ProviderFor(BriefingNotifier)
+final briefingNotifierProvider =
+    AutoDisposeNotifierProvider<BriefingNotifier, BriefingState>.internal(
+  BriefingNotifier.new,
+  name: r'briefingNotifierProvider',
+  debugGetCreateSourceHash: const bool.fromEnvironment('dart.vm.product')
+      ? null
+      : _$briefingNotifierHash,
+  dependencies: null,
+  allTransitiveDependencies: null,
+);
+
+typedef _$BriefingNotifier = AutoDisposeNotifier<BriefingState>;
+// ignore_for_file: type=lint
+// ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, deprecated_member_use_from_same_package


### PR DESCRIPTION
## Remove Mock Data - Use Real API Only

---

### Summary
Removes all hardcoded demo data from `BriefingScreen` and connects it to the real `/ai/briefing` API endpoint.

### Changes
- **NEW** `briefing_provider.dart`: Riverpod provider that calls real API via `aiRepositoryProvider`
- **MODIFIED** `briefing_screen.dart`:
  - Removed `_createDemoBriefing()` method (hardcoded data)
  - Removed local state management (`_isLoading`, `_briefing`, `_error`)
  - Now uses `briefingNotifierProvider` to fetch real data
  - Added empty state when no briefing data available
- **GENERATED** `briefing_provider.g.dart`: Riverpod generated code

### Why This Matters
User requested **real data only, no mocks** for hackathon demo. The Morning Briefing now fetches actual portfolio data from the backend.